### PR TITLE
access: user rights check fix

### DIFF
--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -25,7 +25,7 @@ from invenio.base.globals import cfg
 from invenio.base.helpers import unicodifier
 from invenio.base.utils import toposort_send
 from invenio.ext.sqlalchemy import db
-from invenio.modules.jsonalchemy.wrappers import SmartDict
+from invenio.utils.datastructures import SmartDict
 
 
 from jsonpatch import apply_patch
@@ -123,8 +123,7 @@ class Record(SmartDict):
     @classmethod
     def get_record(cls, recid, *args, **kwargs):
         obj = RecordMetadata.query.get(recid)
-        record = cls(obj.json, model=obj)
-        return record
+        return cls(obj.json, model=obj) if obj else None
 
     def dumps(self, **kwargs):
         # FIXME add keywords filtering

--- a/invenio_records/config.py
+++ b/invenio_records/config.py
@@ -21,7 +21,6 @@
 
 from __future__ import unicode_literals
 
-
 RECORDS_BREADCRUMB_TITLE_KEY = 'title.title'
 """Key used to extract the breadcrumb title from the record."""
 
@@ -43,6 +42,7 @@ continue checking the document specific access rights."""
 
 RECORD_KEY_ALIASSES = {
     'recid': 'control_number',
+    '8560_f': 'electronic_location_and_access.electronic_name',
     '980': 'collections',
     '980__a': 'collections.primary',
     '980__b': 'collections.secondary',

--- a/invenio_records/views.py
+++ b/invenio_records/views.py
@@ -56,8 +56,6 @@ def request_record(f):
     @wraps(f)
     def decorated(recid, *args, **kwargs):
         from invenio.modules.collections.models import Collection
-        from invenio.legacy.search_engine import \
-            guess_primary_collection_of_a_record
 
         from .api import get_record
         from .access import check_user_can_view_record
@@ -71,10 +69,10 @@ def request_record(f):
             abort(404)
 
         g.collection = collection = Collection.query.filter(
-            Collection.name == guess_primary_collection_of_a_record(recid)).\
-            one()
+            Collection.name.in_(record['_collections'])).first()
 
-        (auth_code, auth_msg) = check_user_can_view_record(current_user, recid)
+        (auth_code, auth_msg) = check_user_can_view_record(
+            current_user, record)
 
         # only superadmins can use verbose parameter for obtaining debug
         # information


### PR DESCRIPTION
When accessing any record:
```
17:30:37 web.1       | --------------------------------------------------------------------------------
17:30:37 web.1       | Traceback (most recent call last):
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/src/invenio/invenio/ext/legacy/__init__.py", line 107, in __call__
17:30:37 web.1       |     response = self.app.full_dispatch_request()
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
17:30:37 web.1       |     rv = self.handle_user_exception(e)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/lib/python2.7/site-packages/flask_restful/__init__.py", line 270, in error_router
17:30:37 web.1       |     return original_handler(e)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/src/invenio/invenio/base/wrappers.py", line 133, in handle_user_exception
17:30:37 web.1       |     return super(Flask, self).handle_user_exception(e)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
17:30:37 web.1       |     reraise(exc_type, exc_value, tb)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
17:30:37 web.1       |     rv = self.dispatch_request()
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/lib/python2.7/site-packages/flask_debugtoolbar/__init__.py", line 125, in dispatch_request
17:30:37 web.1       |     return view_func(**req.view_args)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/src/invenio/invenio/base/decorators.py", line 203, in decorator
17:30:37 web.1       |     return f(*args, **argd)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/src/invenio-records/invenio_records/views.py", line 74, in decorated
17:30:37 web.1       |     Collection.name == guess_primary_collection_of_a_record(recid)).\
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/src/invenio/invenio/legacy/search_engine/__init__.py", line 237, in guess_primary_collection_of_a_record
17:30:37 web.1       |     dbcollids = get_fieldvalues(recID, "980__a")
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/src/invenio/invenio/legacy/bibrecord/__init__.py", line 1737, in get_fieldvalues
17:30:37 web.1       |     return get_res(recIDs)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/src/invenio/invenio/legacy/bibrecord/__init__.py", line 1734, in get_res
17:30:37 web.1       |     return [i[0] for i in run_sql(query, tuple(recIDs) + (tag,))]
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/lib/python2.7/site-packages/werkzeug/local.py", line 366, in <lambda>
17:30:37 web.1       |     __call__ = lambda x, *a, **kw: x._get_current_object()(*a, **kw)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/src/invenio/invenio/legacy/dbquery_mysql.py", line 278, in run_sql
17:30:37 web.1       |     rc = cur.execute(sql, param)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/lib/python2.7/site-packages/MySQLdb/cursors.py", line 205, in execute
17:30:37 web.1       |     self.errorhandler(self, exc, value)
17:30:37 web.1       |   File "/Users/egabancho/Work/envs/cdslabs/lib/python2.7/site-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
17:30:37 web.1       |     raise errorclass, errorvalue
17:30:37 web.1       | ProgrammingError: (1146, "Table 'cdslabs.bib98x' doesn't exist")
```