### PR TITLE
views: fix export of non HTML formats

### DIFF
--- a/invenio_records/views.py
+++ b/invenio_records/views.py
@@ -145,7 +145,7 @@ def metadata(recid, of='hd', ot=None):
     if get_output_format_content_type(of) != 'text/html':
         from invenio.modules.search.views.search import \
             response_formated_records
-        return response_formated_records([recid], g.collection, of, qid=None)
+        return response_formated_records([g.record], g.collection, of)
 
     # Send the signal 'document viewed'
     record_viewed.send(


### PR DESCRIPTION
* FIX Fixes export of records in non HTML formats.
  (closes inveniosoftware/invenio#3351)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>