### PR TITLE
api: fix autoflush on get_record

### DIFF
--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -125,7 +125,8 @@ class Record(SmartDict):
 
     @classmethod
     def get_record(cls, recid, *args, **kwargs):
-        obj = RecordMetadata.query.get(recid)
+        with db.session.no_autoflush:
+            obj = RecordMetadata.query.get(recid)
         return cls(obj.json, model=obj) if obj else None
 
     def dumps(self, **kwargs):


### PR DESCRIPTION
* FIX Disables autoflush when pulling records out of the databse, to
  prevent superfluous call to `flush()`. (closes #24)

Signed-off-by: Dimitrios Semitsoglou-Tsiapos <dsemitso@cern.ch>