### PR TITLE
api: record update fix

### DIFF
--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -103,6 +103,9 @@ class Record(SmartDict):
     def commit(self):
         db.session.begin(subtransactions=True)
         try:
+            from invenio.modules.jsonalchemy.registry import functions
+            list(functions('recordext'))
+
             toposort_send(before_record_update, self)
 
             if self.model is None:


### PR DESCRIPTION
* FIX Loads all recordext functions registered before
  updating a record via `Record.commit()`.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>