### PR TITLE
installation: fix invenio_access imports

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -78,6 +78,7 @@ Invenio-Records is a metadata storage module.
 - Raja Sripada <rsripada@cern.ch>
 - Raquel Jimenez Encinar <raquel.jimenez.encinar@cern.ch>
 - Roman Chyla <roman.chyla@cern.ch>
+- Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Samuele Carli <samuele.carli@cern.ch>
 - Samuele Kaplun <samuele.kaplun@cern.ch>
 - Theodoropoulos Theodoros <theod@lib.auth.gr>

--- a/invenio_records/access.py
+++ b/invenio_records/access.py
@@ -78,7 +78,7 @@ def is_user_owner_of_record(user_info, recid):
     :type recid: positive integer
     :return: True if the user is 'owner' of the record; False otherwise
     """
-    from invenio.modules.access.local_config import \
+    from invenio_access.local_config import \
         CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_EMAILS_IN_TAGS, \
         CFG_ACC_GRANT_AUTHOR_RIGHTS_TO_USERIDS_IN_TAGS
 
@@ -111,7 +111,7 @@ def is_user_viewer_of_record(user_info, recid):
     @return: True if the user is 'allow to view' the record; False otherwise
     @rtype: bool
     """
-    from invenio.modules.access.local_config import \
+    from invenio_access.local_config import \
         CFG_ACC_GRANT_VIEWER_RIGHTS_TO_EMAILS_IN_TAGS, \
         CFG_ACC_GRANT_VIEWER_RIGHTS_TO_USERIDS_IN_TAGS
 
@@ -162,8 +162,8 @@ def check_user_can_view_record(user_info, recid):
     :return: (0, ''), when authorization is granted, (>0, 'message') when
     authorization is not granted
     """
-    from invenio.modules.access.engine import acc_authorize_action
-    from invenio.modules.access.local_config import VIEWRESTRCOLL
+    from invenio_access.engine import acc_authorize_action
+    from invenio_access.local_config import VIEWRESTRCOLL
 
     policy = cfg['CFG_WEBSEARCH_VIEWRESTRCOLL_POLICY'].strip().upper()
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -23,6 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 -e git+git://github.com/inveniosoftware/dojson.git#egg=DoJSON
+-e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-collections.git#egg=invenio-collections
 -e git+git://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
 -e git+git://github.com/inveniosoftware/invenio-pidstore.git#egg=invenio-pidstore

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ requirements = [
     'jsonschema>=2.5.1',
     'dojson>=0.1.1',
     # FIXME 'Invenio>2.1',
+    'invenio-access>=0.1.0',
     'invenio-collections>=0.1.0',
     'invenio-formatter>=0.2.0',
     'invenio-pidstore>=0.1.0',  # TODO consider making it optional
@@ -71,6 +72,7 @@ extras_require = {
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]


### PR DESCRIPTION
* Adds missing `invenio_access` dependency and amends past upgrade
  recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>