### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -38,5 +38,5 @@ PACKAGES = [
     'invenio_accounts',
     'invenio_formatter',
     'invenio_upgrader',
-    'invenio.base',
+    'invenio_base',
 ]

--- a/invenio_records/access.py
+++ b/invenio_records/access.py
@@ -21,7 +21,7 @@
 
 from collections import MutableMapping
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio_collections.cache import restricted_collection_cache
 
 from .api import get_record

--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -23,9 +23,9 @@ from flask import current_app
 from jsonpatch import apply_patch
 from jsonschema import validate
 
-from invenio.base.globals import cfg
-from invenio.base.helpers import unicodifier
-from invenio.base.utils import toposort_send
+from invenio_base.globals import cfg
+from invenio_base.helpers import unicodifier
+from invenio_base.utils import toposort_send
 from invenio.ext.sqlalchemy import db
 from invenio.utils.datastructures import SmartDict
 

--- a/invenio_records/manage.py
+++ b/invenio_records/manage.py
@@ -81,7 +81,7 @@ def patch(patch, recid=None, schema=None, input_type='jsonpatch'):
 
 def main():
     """Run manager."""
-    from invenio.base.factory import create_app
+    from invenio_base.factory import create_app
     app = create_app()
     manager.app = app
     manager.run()

--- a/invenio_records/tasks/datacite.py
+++ b/invenio_records/tasks/datacite.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 
 from celery.utils.log import get_task_logger
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.celery import celery
 from invenio_formatter import format_record
 from invenio_pidstore.models import PersistentIdentifier

--- a/invenio_records/utils.py
+++ b/invenio_records/utils.py
@@ -28,7 +28,7 @@ import six
 from flask import g, request
 from werkzeug.utils import cached_property, import_string
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.ext.cache import cache
 
 

--- a/invenio_records/views.py
+++ b/invenio_records/views.py
@@ -36,10 +36,10 @@ from flask_login import current_user
 
 from flask_menu import register_menu
 
-from invenio.base.decorators import wash_arguments
-from invenio.base.globals import cfg
-from invenio.base.i18n import _
-from invenio.base.signals import pre_template_render
+from invenio_base.decorators import wash_arguments
+from invenio_base.globals import cfg
+from invenio_base.i18n import _
+from invenio_base.signals import pre_template_render
 from invenio.ext.template.context_processor import \
     register_template_context_processor
 from invenio.utils import apache

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -24,6 +24,7 @@
 
 -e git+git://github.com/inveniosoftware/dojson.git#egg=DoJSON
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-collections.git#egg=invenio-collections
 -e git+git://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
 -e git+git://github.com/inveniosoftware/invenio-pidstore.git#egg=invenio-pidstore

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ requirements = [
     'jsonschema>=2.5.1',
     'dojson>=0.1.1',
     'invenio-access>=0.1.0',
+    'invenio-base>=0.1.0',
     'invenio-collections>=0.1.2',
     'invenio-formatter>=0.2.1',
     'invenio-pidstore>=0.1.1',  # TODO consider making it optional


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>