### PR TITLE
api: creating record containing specific recid

### DIFF
--- a/invenio_records/errors.py
+++ b/invenio_records/errors.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+
+class InvenioRecordsValueError(Exception):
+    """Exception raised when a new record
+       is not already registered into the system."""
+
+    def __init__(self, message):
+        """Initialization."""
+        super(Exception, self).__init__(message)

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -22,14 +22,16 @@
 from __future__ import unicode_literals
 
 import os
-import pkg_resources
-
-from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
 
 from dojson.contrib.marc21 import marc21
+
 from dojson.contrib.marc21.utils import create_record, split_blob
 
+from invenio.testsuite import InvenioTestCase
+
 from mock import patch
+
+import pkg_resources
 
 
 class TestRecord(InvenioTestCase):
@@ -77,9 +79,30 @@ class TestRecord(InvenioTestCase):
         rec = {'control_number': '1'}
         self.assertRaises(ValidationError, validate, rec, schema)
 
+    def test_incoming_recid(self):
+        from invenio_records.errors import InvenioRecordsValueError
+        """Record - accented Unicode letters."""
+        xml = '''<record>
+          <controlfield tag="001">1000</controlfield>
+          <datafield tag="041" ind1=" " ind2=" ">
+            <subfield code="a">eng</subfield>
+          </datafield>
+          <datafield tag="100" ind1=" " ind2=" ">
+            <subfield code="a">Doe, John</subfield>
+          </datafield>
+          <datafield tag="245" ind1=" " ind2=" ">
+            <subfield code="a">title</subfield>
+          </datafield>
+        </record>
+        '''
+        rec = marc21.do(create_record(xml))
+        from invenio_records.api import Record
+        with self.assertRaises(InvenioRecordsValueError):
+            Record.create(rec)
+
 
 class NoTest:
-# class TestLegacyExport(InvenioTestCase):
+    # class TestLegacyExport(InvenioTestCase):
     """Record - Legacy methods test."""
 
     def test_legacy_export_marcxml(self):
@@ -472,12 +495,15 @@ class TestMarcRecordCreation(InvenioTestCase):
 
         assert 'main_entry_personal_name' in r
         assert 'added_entry_personal_name' in r
-        assert r['main_entry_personal_name']['personal_name'] == "Efstathiou, G P"
+        assert r['main_entry_personal_name'][
+            'personal_name'] == "Efstathiou, G P"
         assert len(r['added_entry_personal_name']) == 4
         assert 'title_statement' in r
-        assert r['title_statement']['title'] == "Constraints on $\Omega_{\Lambda}$ and $\Omega_{m}$from Distant Type 1a Supernovae and Cosmic Microwave Background Anisotropies"
+        assert r['title_statement'][
+            'title'] == "Constraints on $\Omega_{\Lambda}$ and $\Omega_{m}$from Distant Type 1a Supernovae and Cosmic Microwave Background Anisotropies"
         assert 'summary' in r
-        assert r['summary'][0]['summary'] == "We perform a combined likelihood analysis of the latest cosmic microwave background anisotropy data and distant Type 1a Supernova data of Perlmutter etal (1998a). Our analysis is restricted tocosmological models where structure forms from adiabatic initial fluctuations characterised by a power-law spectrum with negligible tensor component. Marginalizing over other parameters, our bestfit solution gives Omega_m = 0.25 (+0.18, -0.12) and Omega_Lambda = 0.63 (+0.17, -0.23) (95 % confidence errors) for the cosmic densities contributed by matter and a cosmological constantrespectively. The results therefore strongly favour a nearly spatially flat Universe with a non-zero cosmological constant."
+        assert r['summary'][0][
+            'summary'] == "We perform a combined likelihood analysis of the latest cosmic microwave background anisotropy data and distant Type 1a Supernova data of Perlmutter etal (1998a). Our analysis is restricted tocosmological models where structure forms from adiabatic initial fluctuations characterised by a power-law spectrum with negligible tensor component. Marginalizing over other parameters, our bestfit solution gives Omega_m = 0.25 (+0.18, -0.12) and Omega_Lambda = 0.63 (+0.17, -0.23) (95 % confidence errors) for the cosmic densities contributed by matter and a cosmological constantrespectively. The results therefore strongly favour a nearly spatially flat Universe with a non-zero cosmological constant."
 
         # self.assertTrue('reference' in r)
         # self.assertEquals(len(r['reference']), 36)
@@ -500,7 +526,7 @@ class TestMarcRecordCreation(InvenioTestCase):
 
 
 class NoTest:
-#class TestRecordDocuments(InvenioTestCase):
+    # class TestRecordDocuments(InvenioTestCase):
 
     """Test record doccuments behaviour."""
 


### PR DESCRIPTION
* Adds an exception that raises when a new record
  is not already registered into the system.

* Adds an exception handler in the 'create' method of api raising
  the new exception.

* Adds a test case for inserting a record with a specific recid.
  (closes #39) (addresses #40)

Signed-off-by: Panos Paparrigopoulos <panos.paparrigopoulos@cern.ch>