### PR TITLE
tasks: removal of submodule init imports

### DIFF
--- a/invenio_records/tasks/__init__.py
+++ b/invenio_records/tasks/__init__.py
@@ -18,11 +18,3 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 """Define Celery tasks."""
-
-from __future__ import absolute_import
-
-from .api import create_record
-
-__all__ = (
-    'create_record',
-)


### PR DESCRIPTION
* Removes imports from tasks submodule init.py. (closes #59)

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>