### PR TITLE
global: uuid record identifier

### DIFF
--- a/invenio_records/cli.py
+++ b/invenio_records/cli.py
@@ -45,10 +45,9 @@ def records():
 
 @records.command()
 @click.argument('source', type=click.File('r'), default=sys.stdin)
-@click.option('-s', '--schema', default=None)
 @click.option('--force', is_flag=True, default=False)
 @with_appcontext
-def create(source, schema, force):
+def create(source, force):
     """Create new bibliographic record(s)."""
     from .tasks.api import create_record
     data = json.load(source)
@@ -63,16 +62,15 @@ def create(source, schema, force):
 
 @records.command()
 @click.argument('patch', type=click.File('r'), default=sys.stdin)
-@click.option('-r', '--recid', multiple=True)
-@click.option('-s', '--schema', default=None)
+@click.option('-r', '--record', multiple=True)
 @with_appcontext
-def patch(patch, recid, schema):
+def patch(patch, record):
     """Patch existing bibliographic record."""
     from .api import Record
 
     patch_content = patch.read()
 
-    if recid:
-        for r in recid:
-            Record.get_record(int(r)).patch(patch_content).commit()
+    if record:
+        for rec in record:
+            Record.get_record(rec).patch(patch_content).commit()
         db.session.commit()

--- a/invenio_records/errors.py
+++ b/invenio_records/errors.py
@@ -22,21 +22,14 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Package configuration."""
+"""Errors for records module."""
 
-RECORDS_BREADCRUMB_TITLE_KEY = 'title_statement.title'
-"""Key used to extract the breadcrumb title from the record."""
+from __future__ import absolute_import, print_function
 
-RECORDS_PROCESSORS = {
-    'json': 'json.load',
-    'marcxml': 'invenio_records.cli:_convert_marcxml',
-}
-"""Processors used to create records."""
 
-RECORDS_KEY_ALIASES = {
-    'recid': 'control_number',
-    '8560_f': 'electronic_location_and_access.electronic_name',
-    '980': 'collections',
-    '980__a': 'collections.primary',
-    '980__b': 'collections.secondary',
-}
+class RecordsError(Exception):
+    """Base class for errors in records module."""
+
+
+class RecordNotCommitableError(RecordsError):
+    """Error raised when record has no model and thus not commitable."""

--- a/invenio_records/models.py
+++ b/invenio_records/models.py
@@ -25,11 +25,11 @@
 """Record models."""
 
 import pkg_resources
-
+import uuid
 from invenio_db import db
 from sqlalchemy_continuum import make_versioned
 from sqlalchemy_utils.models import Timestamp
-from sqlalchemy_utils.types import JSONType
+from sqlalchemy_utils.types import JSONType, UUIDType
 
 try:
     pkg_resources.get_distribution('invenio_accounts')
@@ -41,7 +41,7 @@ else:
 make_versioned(user_cls=user_cls)
 
 
-class Record(db.Model, Timestamp):
+class RecordMetadata(db.Model, Timestamp):
     """Represent a record metadata inside the SQL database.
 
     Additionally it contains two columns ``created`` and ``updated``
@@ -54,10 +54,11 @@ class Record(db.Model, Timestamp):
     __tablename__ = 'record'
 
     id = db.Column(
-        db.Integer,
+        UUIDType,
         primary_key=True,
-        autoincrement=True,
+        default=uuid.uuid4,
     )
+    """Record identifier."""
 
     json = db.Column(JSONType, default=lambda: dict(), nullable=True)
     """Store metadata in JSON format.
@@ -68,7 +69,7 @@ class Record(db.Model, Timestamp):
     """
 
     version_id = db.Column(db.Integer, nullable=False)
-    """It is used by SQLAlchemy for optimistic concurency control."""
+    """It is used by SQLAlchemy for optimistic concurrency control."""
 
     __mapper_args__ = {
         'version_id_col': version_id
@@ -76,5 +77,5 @@ class Record(db.Model, Timestamp):
 
 
 __all__ = (
-    'Record',
+    'RecordMetadata',
 )

--- a/invenio_records/tasks/api.py
+++ b/invenio_records/tasks/api.py
@@ -32,15 +32,16 @@ logger = get_task_logger(__name__)
 
 
 @shared_task
-def create_record(data=None, force=False):
+def create_record(data=None, id_=None, force=False):
     """Create record from given data."""
     from invenio_db import db
     try:
-        return Record.create(data).get('recid')
+        return Record.create(data, id_=id_).id
     except exc.IntegrityError:
         if force:
             current_app.logger.warning(
-                "Trying to force insert: {0}".format(data))
-            return Record(data).commit().get('recid')
+                "Trying to force insert: {0}".format(id_))
+            record = Record.get_record(id_)
+            return Record(data, model=record.model).commit().id
     finally:
         db.session.commit()

--- a/tests/test_invenio_records.py
+++ b/tests/test_invenio_records.py
@@ -28,6 +28,7 @@ from __future__ import absolute_import, print_function
 
 import json
 import os
+import uuid
 
 import pytest
 from click.testing import CliRunner
@@ -36,9 +37,11 @@ from flask_celeryext import create_celery_app
 from flask_cli import FlaskCLI, ScriptInfo
 from invenio_db import InvenioDB, db
 from invenio_db.cli import db as db_cmd
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy_utils.functions import create_database, drop_database
 
 from invenio_records import InvenioRecords, Record, cli
+from invenio_records.errors import RecordNotCommitableError
 
 
 def test_version():
@@ -72,31 +75,30 @@ def test_db():
     InvenioDB(app)
     InvenioRecords(app)
 
-    runner = CliRunner()
-    script_info = ScriptInfo(create_app=lambda info: app)
-
     with app.app_context():
         create_database(db.engine.url)
         db.create_all()
         assert len(db.metadata.tables) == 3
 
-    data = {'recid': 1, 'title': 'Test'}
-    from invenio_records.models import Record as RM
+    data = {'title': 'Test'}
+    from invenio_records.models import RecordMetadata as RM
 
+    # Create a record
     with app.app_context():
         assert RM.query.count() == 0
 
-        Record.create(data)
+        record_uuid = Record.create(data).id
         db.session.commit()
 
         assert RM.query.count() == 1
         db.session.commit()
 
+    # Retrieve created record
     with app.app_context():
-        record = Record.get_record(1)
+        record = Record.get_record(record_uuid)
         assert record.dumps() == data
-        with pytest.raises(Exception):
-            Record.get_record(2)
+        with pytest.raises(NoResultFound):
+            Record.get_record(uuid.uuid4())
         record['field'] = True
         record = record.patch([
             {'op': 'add', 'path': '/hello', 'value': ['world']}
@@ -106,21 +108,17 @@ def test_db():
         db.session.commit()
 
     with app.app_context():
-        record2 = Record.get_record(1)
+        record2 = Record.get_record(record_uuid)
         assert record2.model.version_id == 2
         assert record2['field']
         assert record2['hello'] == ['world']
         db.session.commit()
 
+    # Cannot commit record without model (i.e. Record.create_record)
     with app.app_context():
-        record3 = Record({'recid': 1})
-        record3.commit()
-        db.session.commit()
-
-        record = Record.get_record(1)
-        assert record.model.version_id == 3
-        assert set(record.dumps().keys()) == set(['recid'])
-        db.session.commit()
+        record3 = Record({'title': 'Not possible'})
+        with pytest.raises(RecordNotCommitableError):
+            record3.commit()
 
     with app.app_context():
         db.drop_all()
@@ -145,12 +143,14 @@ def test_cli():
     InvenioDB(app)
     InvenioRecords(app)
 
-    celery = create_celery_app(app)
+    create_celery_app(app)
 
     runner = CliRunner()
     script_info = ScriptInfo(create_app=lambda info: app)
 
     assert len(db.metadata.tables) == 3
+
+    from invenio_records.models import RecordMetadata as RM
 
     # Test merging a base another file.
     with runner.isolated_filesystem():
@@ -170,20 +170,24 @@ def test_cli():
         result = runner.invoke(cli.records, [], obj=script_info)
         assert result.exit_code == 0
 
+        with app.app_context():
+            assert RM.query.count() == 0
+
         result = runner.invoke(cli.records, ['create', 'record.json'],
                                obj=script_info)
         assert result.exit_code == 0
 
         with app.app_context():
-            assert Record.get_record(1)['title'] == 'Test'
+            assert RM.query.count() == 1
+            recid = RM.query.first().id
 
         result = runner.invoke(cli.records,
-                               ['patch', 'record.patch', '-r', '1'],
+                               ['patch', 'record.patch', '-r', recid],
                                obj=script_info)
         assert result.exit_code == 0
 
         with app.app_context():
-            record = Record.get_record(1)
+            record = Record.get_record(recid)
             assert record['title'] == 'Patched Test'
             assert record.model.version_id == 2
 


### PR DESCRIPTION
More PRs in the pipeline, so don't merge until the complete picture is there.


* INCOMPATIBLE Changes primary key of records to UUIDType instead of
  auto-incrementing integers.

* INCOMPATIBLE Removes functional interface to records.

* INCOMPATIBLE Renames SQLAlchemy model from Record to RecordMetadata
  to avoid naming confusion with API Record class.

* FIX Fixes typo in configuration variables.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>