### PR TITLE
models: standardizes table names

### DIFF
--- a/invenio_records/models.py
+++ b/invenio_records/models.py
@@ -51,7 +51,7 @@ class RecordMetadata(db.Model, Timestamp):
     # Enables SQLAlchemy-Continuum versioning
     __versioned__ = {}
 
-    __tablename__ = 'record'
+    __tablename__ = 'records_metadata'
 
     id = db.Column(
         UUIDType,


### PR DESCRIPTION
* Changed RecordMetadata table name to follow the naming conventions.
  (closes #63)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>