### PR TITLE
api: revision and delete support

### DIFF
--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -28,15 +28,17 @@ from flask import current_app
 from invenio_db import db
 from jsonpatch import apply_patch
 from jsonschema import validate
+from sqlalchemy.orm.exc import NoResultFound
 
-from .errors import RecordNotCommitableError
+from .errors import MissingModelError
 from .models import RecordMetadata
-from .signals import after_record_insert, after_record_update, \
-    before_record_insert, before_record_update
+from .signals import after_record_delete, after_record_insert, \
+    after_record_revert, after_record_update, before_record_delete, \
+    before_record_insert, before_record_revert, before_record_update
 
 
-class Record(dict):
-    """Define API for metadata creation and manipulation."""
+class RecordBase(dict):
+    """Base class for Record and RecordBase."""
 
     @property
     def __key_aliases__(self):
@@ -46,13 +48,13 @@ class Record(dict):
     def __getitem__(self, key):
         """Try to get aliased item on ``KeyError``."""
         try:
-            return super(Record, self).__getitem__(key)
+            return super(RecordBase, self).__getitem__(key)
         except KeyError:
             if key in self.__key_aliases__:
                 if callable(self.__key_aliases__[key]):
                     return self.__key_aliases__[key](self, key)
                 else:
-                    return super(Record, self).__getitem__(
+                    return super(RecordBase, self).__getitem__(
                         self.__key_aliases__[key]
                     )
             raise
@@ -62,10 +64,53 @@ class Record(dict):
         if key in self.__key_aliases__:
             if callable(self.__key_aliases__[key]):
                 raise TypeError('Complex aliases can not be set')
-            return super(Record, self).__setitem__(
+            return super(RecordBase, self).__setitem__(
                 self.__key_aliases__[key], value
             )
-        return super(Record, self).__setitem__(key, value)
+        return super(RecordBase, self).__setitem__(key, value)
+
+    def __init__(self, data, model=None):
+        """Initialize instance with dictionary data and SQLAlchemy model.
+
+        :param data: dict with record metadata
+        :param model: :class:`~invenio_records.models.RecordMetadata` instance
+        """
+        self.model = model
+        super(RecordBase, self).__init__(data or {})
+
+    @property
+    def id(self):
+        """Get model identifier."""
+        return self.model.id if self.model else None
+
+    @property
+    def revision_id(self):
+        """Get revision identifier."""
+        return self.model.version_id-1 if self.model else None
+
+    @property
+    def created(self):
+        """Get creation timestamp."""
+        return self.model.created if self.model else None
+
+    @property
+    def updated(self):
+        """Get last updated timestamp."""
+        return self.model.updated if self.model else None
+
+    def validate(self):
+        """Validate record according to schema defined in ``$schema`` key."""
+        if '$schema' in self:
+            return validate(self, self['$schema'])
+        return True
+
+    def dumps(self, **kwargs):
+        """Return pure Python dictionary with record metadata."""
+        return dict(self)
+
+
+class Record(RecordBase):
+    """Define API for metadata creation and manipulation."""
 
     @classmethod
     def create(cls, data, id_=None):
@@ -85,28 +130,18 @@ class Record(dict):
         return record
 
     @classmethod
-    def get_record(cls, id):
+    def get_record(cls, id, with_deleted=False):
         """Get record instance.
 
         Raises database exception if record does not exists.
         """
         with db.session.no_autoflush:
             obj = RecordMetadata.query.filter_by(id=id).one()
+            # PostgreSQL JSON type stores None as a JSON value "null", while
+            # MySQL and SQLite stores None as a database null value.
+            if not with_deleted and obj.json is None:
+                raise NoResultFound()
             return cls(obj.json, model=obj)
-
-    def __init__(self, data, model=None):
-        """Initialize instance with dictionary data and SQLAlchemy model.
-
-        :param data: dict with record metadata
-        :param model: :class:`~invenio_records.models.RecordMetadata` instance
-        """
-        self.model = model
-        super(Record, self).__init__(data)
-
-    @property
-    def id(self):
-        """Get model identifier."""
-        return self.model.id if self.model else None
 
     def patch(self, patch):
         """Patch record metadata."""
@@ -115,8 +150,8 @@ class Record(dict):
 
     def commit(self):
         """Store changes on current instance in database."""
-        if self.model is None:
-            raise RecordNotCommitableError()
+        if self.model is None or self.model.json is None:
+            raise MissingModelError()
 
         with db.session.begin_nested():
             before_record_update.send(self)
@@ -130,12 +165,99 @@ class Record(dict):
         after_record_update.send(self)
         return self
 
-    def validate(self):
-        """Validate record according to schema defined in ``$schema`` key."""
-        if '$schema' in self:
-            return validate(self, self['$schema'])
-        return True
+    def delete(self, force=False):
+        """Delete a record.
 
-    def dumps(self, **kwargs):
-        """Return pure Python dictionary with record metadata."""
-        return dict(self)
+        If `force` is ``False``, the record is soft-deleted, i.e. the record
+        stays in the database. This ensures e.g. that the same record
+        identifier cannot be used twice, and that you can still retrieve the
+        history of an object. If `force` is True, the record is completely
+        removed from the database.
+
+        :param force: Completely remove record from database.
+        """
+        if self.model is None:
+            raise MissingModelError()
+
+        with db.session.begin_nested():
+            before_record_delete.send(self)
+
+            if force:
+                db.session.delete(self.model)
+            else:
+                self.model.json = None
+                db.session.merge(self.model)
+
+        after_record_delete.send(self)
+        return self
+
+    def revert(self, revision_id):
+        """Revert to a specific revision."""
+        if self.model is None:
+            raise MissingModelError()
+
+        revision = self.revisions[revision_id]
+
+        with db.session.begin_nested():
+            before_record_revert.send(self)
+
+            self.model.json = dict(revision)
+
+            db.session.merge(self.model)
+
+        after_record_revert.send(self)
+        return self.__class__(self.model.json, model=self.model)
+
+    @property
+    def revisions(self):
+        """Get revision iterator."""
+        if self.model is None:
+            raise MissingModelError()
+
+        return RevisionsIterator(self.model)
+
+
+class RecordRevision(RecordBase):
+    """API for record revisions."""
+
+    def __init__(self, model):
+        """Initialize revision."""
+        super(RecordRevision, self).__init__(model.json, model=model)
+
+
+class RevisionsIterator(object):
+    """Iterator for record revisions."""
+
+    def __init__(self, model):
+        """Initialize iterator."""
+        self._it = None
+        self.model = model
+
+    def __len__(self):
+        """Get number of revisions."""
+        return self.model.versions.count()
+
+    def __iter__(self):
+        """Get iterator."""
+        self._it = iter(self.model.versions)
+        return self
+
+    def next(self):
+        """Python 2.7 compatibility."""
+        return self.__next__()  # pragma: no cover
+
+    def __next__(self):
+        """Get next revision item."""
+        return RecordRevision(next(self._it))
+
+    def __getitem__(self, revision_id):
+        """Get a specific revision."""
+        return RecordRevision(self.model.versions[revision_id])
+
+    def __contains__(self, revision_id):
+        """Test if revision exists."""
+        try:
+            self[revision_id]
+            return True
+        except IndexError:
+            return False

--- a/invenio_records/errors.py
+++ b/invenio_records/errors.py
@@ -31,5 +31,5 @@ class RecordsError(Exception):
     """Base class for errors in records module."""
 
 
-class RecordNotCommitableError(RecordsError):
-    """Error raised when record has no model and thus not commitable."""
+class MissingModelError(RecordsError):
+    """Error raised when record has no model."""

--- a/invenio_records/signals.py
+++ b/invenio_records/signals.py
@@ -74,3 +74,15 @@ before_record_update = _signals.signal('before-record-update')
 
 after_record_update = _signals.signal('after-record-update')
 """Signal sent after a record is updated."""
+
+before_record_delete = _signals.signal('before-record-delete')
+"""Signal is sent before a record is delete."""
+
+after_record_delete = _signals.signal('after-record-delete')
+"""Signal sent after a record is delete."""
+
+before_record_revert = _signals.signal('before-record-revert')
+"""Signal is sent before a record is revert."""
+
+after_record_revert = _signals.signal('after-record-revert')
+"""Signal sent after a record is revert."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test Invenio Records API."""
+
+from __future__ import absolute_import, print_function
+
+from datetime import datetime, timedelta
+
+import pytest
+from invenio_db import db
+from sqlalchemy.orm.exc import NoResultFound
+
+from invenio_records import Record
+from invenio_records.errors import MissingModelError
+
+
+def strip_ms(dt):
+    """Strip microseconds."""
+    return dt - timedelta(microseconds=dt.microsecond)
+
+
+def test_revision_id_created_updated_properties(app):
+    """Test properties."""
+    with app.app_context():
+        record = Record.create({'title': 'test'})
+        assert record.revision_id == 0
+        dt_c = record.created
+        assert dt_c
+        dt_u = record.updated
+        assert dt_u
+        record['title'] = 'test 2'
+        record.commit()
+        db.session.commit()
+        assert record.revision_id == 1
+        assert strip_ms(record.created) == strip_ms(dt_c)
+        assert strip_ms(record.updated) >= strip_ms(dt_u)
+
+        assert dt_u.tzinfo is None
+        utcnow = datetime.utcnow()
+        assert dt_u > utcnow - timedelta(seconds=10)
+        assert dt_u < utcnow + timedelta(seconds=10)
+
+
+def test_delete(app):
+    """Test delete a record."""
+    with app.app_context():
+        # Create a record, revise it and delete it.
+        record = Record.create({'title': 'test 1'})
+        db.session.commit()
+        record['title'] = 'test 2'
+        record.commit()
+        db.session.commit()
+        record.delete()
+        db.session.commit()
+
+        # Deleted records a not retrievable by default
+        pytest.raises(NoResultFound, Record.get_record, record.id)
+
+        # Deleted records can be retrieved if you explicit request it
+        record = Record.get_record(record.id, with_deleted=True)
+
+        # Deleted records are empty
+        assert record == {}
+        assert record.model.json is None
+
+        # Deleted records *cannot* be modified
+        record['title'] = 'deleted'
+        assert pytest.raises(MissingModelError, record.commit)
+
+        # Deleted records *can* be reverted
+        record = record.revert(-2)
+        assert record['title'] == 'test 2'
+        db.session.commit()
+
+        # The "undeleted" record can now be retrieve again
+        record = Record.get_record(record.id)
+        assert record['title'] == 'test 2'
+
+        # Force deleted record cannot be retrieved again
+        record.delete(force=True)
+        db.session.commit()
+        pytest.raises(
+            NoResultFound, Record.get_record, record.id,
+            with_deleted=True)
+
+
+def test_revisions(app):
+    """Test revisions."""
+    with app.app_context():
+        # Create a record and make modifications to it.
+        record = Record.create({'title': 'test 1'})
+        rec_uuid = record.id
+        db.session.commit()
+        record['title'] = 'test 2'
+        record.commit()
+        db.session.commit()
+        record['title'] = 'test 3'
+        record.commit()
+        db.session.commit()
+
+        # Get the record
+        record = Record.get_record(rec_uuid)
+        assert record['title'] == 'test 3'
+        assert record.revision_id == 2
+
+        # Retrieve specific revisions
+        rev1 = record.revisions[0]
+        assert rev1['title'] == 'test 1'
+        assert rev1.revision_id == 0
+
+        rev2 = record.revisions[1]
+        assert rev2['title'] == 'test 2'
+        assert rev2.revision_id == 1
+
+        # Latest revision is identical to record.
+        rev_latest = record.revisions[-1]
+        assert dict(rev_latest) == dict(record)
+
+        # Revert to a specific revision
+        record = record.revert(rev1.revision_id)
+        assert record['title'] == 'test 1'
+        assert record.created == rev1.created
+        assert record.updated != rev1.updated
+        assert record.revision_id == 3
+        db.session.commit()
+
+        # Get the record again and check it
+        record = Record.get_record(rec_uuid)
+        assert record['title'] == 'test 1'
+        assert record.revision_id == 3
+
+        # Make a change and ensure revision id is changed as well.
+        record['title'] = 'modification'
+        record.commit()
+        db.session.commit()
+        assert record.revision_id == 4
+
+        # Iterate over revisions
+        assert len(record.revisions) == 5
+        revs = list(record.revisions)
+        assert revs[0]['title'] == 'test 1'
+        assert revs[1]['title'] == 'test 2'
+        assert revs[2]['title'] == 'test 3'
+        assert revs[3]['title'] == 'test 1'
+        assert revs[4]['title'] == 'modification'
+
+        assert 2 in record.revisions
+        assert 5 not in record.revisions
+
+
+def test_missing_model(app):
+    """Test revisions."""
+    with app.app_context():
+        record = Record({})
+        assert record.id is None
+        assert record.revision_id is None
+        assert record.created is None
+        assert record.updated is None
+
+        try:
+            record.revisions
+            assert False
+        except MissingModelError:
+            assert True
+
+        pytest.raises(MissingModelError, record.commit)
+        pytest.raises(MissingModelError, record.delete)
+        pytest.raises(MissingModelError, record.revert, -1)


### PR DESCRIPTION
* NEW Adds support for retrieving past revisions of a record as well
  as reverting a record to a past revision. (closes #10)

* NEW Adds support for deleting records. (closes #64)

* BETTER Adds support in API for accessing a records revision id and
  creation/modification timestamps.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>