### PR TITLE
api: fix appending to iterable in JSON

### DIFF
--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -27,6 +27,7 @@
 from flask import current_app
 from invenio_db import db
 from jsonpatch import apply_patch
+from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.local import LocalProxy
 
@@ -166,6 +167,7 @@ class Record(RecordBase):
             self.validate()
 
             self.model.json = dict(self)
+            flag_modified(self.model, 'json')
 
             db.session.merge(self.model)
 


### PR DESCRIPTION
It seems that it's not so easy to update an iterable key within the record:

Is this:
```
rec['some_iterable'].append('foo_item')
```
unsupported in favour of:
```
rec['some_iterable'] = rec['some_iterable'] + ['foo_item', ]
```
?