### PR TITLE
config: additional validation types

### DIFF
--- a/invenio_records/config.py
+++ b/invenio_records/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -40,3 +40,6 @@ RECORDS_KEY_ALIASES = {
     '980__a': 'collections.primary',
     '980__b': 'collections.secondary',
 }
+
+RECORDS_VALIDATION_TYPES = {}
+"""Pass additional types when validating record against schema."""

--- a/invenio_records/ext.py
+++ b/invenio_records/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -51,6 +51,9 @@ class _RecordsState(object):
         if not isinstance(schema, dict):
             schema = {'$ref': schema}
         return validate(data, schema,
+                        types=self.app.config.get(
+                            "RECORDS_VALIDATION_TYPES", {}
+                        ),
                         resolver=self.ref_resolver_cls.from_schema(schema))
 
     def replace_refs(self, data):

--- a/tests/test_invenio_records.py
+++ b/tests/test_invenio_records.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -77,6 +77,7 @@ def test_db():
     InvenioRecords(app)
 
     with app.app_context():
+        db.drop_all()
         db.create_all()
         assert 'records_metadata' in db.metadata.tables
         assert 'records_metadata_version' in db.metadata.tables
@@ -131,6 +132,7 @@ def test_db():
         with pytest.raises(MissingModelError):
             record3.commit()
 
+    # Check invalid schema values
     with app.app_context():
         data = {
             '$schema': 'http://json-schema.org/geo#',
@@ -143,6 +145,21 @@ def test_db():
         record_with_schema['latitude'] = 'invalid'
         with pytest.raises(ValidationError):
             record_with_schema.commit()
+
+    # Allow types overriding on schema validation
+    with app.app_context():
+        data = {
+            'title': 'Test',
+            'hello': tuple(['foo', 'bar']),
+            '$schema': schema
+        }
+        app.config['RECORDS_VALIDATION_TYPES'] = {}
+        with pytest.raises(ValidationError):
+            Record.create(data).commit()
+
+        app.config['RECORDS_VALIDATION_TYPES'] = {'array': (list, tuple)}
+        record_uuid = Record.create(data).commit()
+        db.session.commit()
 
     with app.app_context():
         db.drop_all()


### PR DESCRIPTION
* NEW Adds support for passing additional validation types when
  validating records with `jsonschema` via `RECORDS_VALIDATION_TYPES`
  configuration variable. For example, to allow `array`
  type to be `list` and `tuple` instead of `list` only.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>