### PR TITLE
api: record dump fix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,13 +27,14 @@ from __future__ import print_function
 import os
 
 import sphinx.environment
-from docutils.utils import get_source_line
+
+_warn_node_old = sphinx.environment.BuildEnvironment.warn_node
 
 
-def _warn_node(self, msg, node):
+def _warn_node(self, msg, *args, **kwargs):
     """Do not warn on external images."""
     if not msg.startswith('nonlocal image URI found:'):
-        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+        _warn_node_old(self, msg, *args, **kwargs)
 
 sphinx.environment.BuildEnvironment.warn_node = _warn_node
 

--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -26,6 +26,8 @@
 
 from __future__ import absolute_import, print_function
 
+from copy import deepcopy
+
 from flask import current_app
 from invenio_db import db
 from jsonpatch import apply_patch
@@ -85,7 +87,7 @@ class RecordBase(dict):
 
     def dumps(self, **kwargs):
         """Return pure Python dictionary with record metadata."""
-        return dict(self)
+        return deepcopy(dict(self))
 
 
 class Record(RecordBase):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -307,8 +307,17 @@ def test_record_replace_refs(app, db):
     assert out_json == expected_json
 
 
-def test_replace_refs_deepcpoy(app):
+def test_replace_refs_deepcopy(app):
     """Test problem with replace_refs and deepcopy."""
     with app.app_context():
         assert copy.deepcopy(Record({'recid': 1}).replace_refs()) \
             == {'recid': 1}
+
+
+def test_record_dump(app, db):
+    """Test record dump method."""
+    with app.app_context():
+        record = Record.create({'foo': {'bar': 'Bazz', }, })
+        record_dump = record.dumps()
+        record_dump['foo']['bar'] = 'Spam'
+        assert record_dump['foo']['bar'] != record['foo']['bar']


### PR DESCRIPTION
* Record.dumps method returns a deep-copied dictionary.

Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>