### PR TITLE
data: affiliation fix in MARC bibliographic

### DIFF
--- a/invenio_records/data/marc21/bibliographic.xml
+++ b/invenio_records/data/marc21/bibliographic.xml
@@ -3968,7 +3968,6 @@
     </datafield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">Mück, W</subfield>
-      <subfield code="u">INFN</subfield>
       <subfield code="u">Universita di Napoli</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
@@ -4283,7 +4282,6 @@
     </datafield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">Girardello, L</subfield>
-      <subfield code="u">INFN</subfield>
       <subfield code="u">Universita di Milano-Bicocca</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">


### PR DESCRIPTION
* FIX Amends demo file containing MARC bibliographic records in order to
  remove repetitive affiliations in author fields. This is not allowed
  by the MARC21 standard and was preventing the population of the
  Invenio demo site.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>