### PR TITLE
api: addition of FormatChecker support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -46,6 +46,7 @@ Invenio-Records is a metadata storage module.
 - Grzegorz Szpura <grzegorz.szpura@cern.ch>
 - Guillaume Lastecoueres <PX9e@gmx.fr>
 - Henning Weiler <henning.weiler@cern.ch>
+- Jacopo Notarstefano <jacopo.notarstefano@cern.ch>
 - Jaime García <jaime.garcia.llopis@cern.ch>
 - Jan Aage Lavik <jan.age.lavik@cern.ch>
 - Jan Iwaszkiewicz <jan.iwaszkiewicz@cern.ch>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -328,4 +328,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'https://docs.python.org/': None,
+    'https://python-jsonschema.readthedocs.io/en/latest': None,
+}

--- a/invenio_records/ext.py
+++ b/invenio_records/ext.py
@@ -46,15 +46,17 @@ class _RecordsState(object):
         self.ref_resolver_cls = ref_resolver_factory(self.resolver)
         self.loader_cls = json_loader_factory(self.resolver)
 
-    def validate(self, data, schema):
+    def validate(self, data, schema, **kwargs):
         """Validate data using schema with ``JSONResolver``."""
         if not isinstance(schema, dict):
             schema = {'$ref': schema}
-        return validate(data, schema,
-                        types=self.app.config.get(
-                            "RECORDS_VALIDATION_TYPES", {}
-                        ),
-                        resolver=self.ref_resolver_cls.from_schema(schema))
+        return validate(
+            data,
+            schema,
+            resolver=self.ref_resolver_cls.from_schema(schema),
+            types=self.app.config.get('RECORDS_VALIDATION_TYPES', {}),
+            **kwargs
+        )
 
     def replace_refs(self, data):
         """Replace the JSON reference objects with ``JsonRef``."""


### PR DESCRIPTION
* Makes the FormatChecker feature of jsonschema accessible by allowing
  arbitrary keyword arguments in calls to validate and create, which
  are passed to the underlying jsonschema implementation (closes #142).

* Adds a reminder about this jsonschema feature in the documentation,
  and a complete example as a test.

Signed-off-by: Jacopo Notarstefano <jacopo.notarstefano@cern.ch>