### PR TITLE
docs: index.rst typo fix

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -70,6 +70,7 @@ Invenio-Records is a metadata storage module.
 - Mike Sullivan <sul@slac.stanford.edu>
 - Nikolaos Kasioumis <nikolaos.kasioumis@cern.ch>
 - Olivier Serres <olivier.serres@gmail.com>
+- Orestis Melkonian <melkon.or@gmail.com>
 - Pablo Vázquez Caderno <pcaderno@cern.ch>
 - Patrick Glauner <patrick.oliver.glauner@cern.ch>
 - Paulo Cabral <paulo.cabral@cern.ch>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ User's Guide
 ------------
 
 This part of the documentation will show you how to get started in using
-Invenio-Base.
+Invenio-Records.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
* Fixes typo in index.rst that addresses the module as Invenio-Base
  instead of Invenio-Records.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>