### PR TITLE
docs: debugging instructions fix

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -28,6 +28,7 @@ Create database and tables::
 
    $ cd examples
    $ export FLASK_APP=app.py
+   $ export FLASK_DEBUG=1
    $ mkdir -p instance
    $ flask db init
    $ flask db create
@@ -39,7 +40,7 @@ Create test record::
 
 Run the development server::
 
-   $ flask --debug run --debugger
+   $ flask run
 
 Retrieve record via web::
 


### PR DESCRIPTION
 * Fixes the debugging instructions in examples/app.py (closes #151)

Signed-off-by: Diego Rodriguez Rodriguez <diego.rodriguez.rodriguez@cern.ch>