### PR TITLE
validators: partial validator addition

### DIFF
--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -240,8 +240,8 @@ class Record(RecordBase):
         data = apply_patch(dict(self), patch)
         return self.__class__(data, model=self.model)
 
-    def commit(self):
-        """Store changes on current instance in database.
+    def commit(self, **kwargs):
+        r"""Store changes on current instance in database.
 
         Procedure followed:
 
@@ -255,7 +255,19 @@ class Record(RecordBase):
         #. The signal :data:`invenio_records.signals.after_record_insert` is
             called with the record as function parameter.
 
+        :param \**kwargs: See below.
         :returns: The Record instance.
+
+        :Keyword Arguments:
+          * **format_checker** --
+            An instance of class :class:`jsonschema.FormatChecker`, which
+            contains validation rules for formats. See
+            :func:`~invenio_records.api.RecordBase.validate` for details.
+
+          * **validator** --
+            A :class:`jsonschema.IValidator` class that will be used to
+            validate. See :func:`~invenio_records.api.RecordBase.validate` for
+            details.
         """
         if self.model is None or self.model.json is None:
             raise MissingModelError()
@@ -263,7 +275,7 @@ class Record(RecordBase):
         with db.session.begin_nested():
             before_record_update.send(self)
 
-            self.validate()
+            self.validate(**kwargs)
 
             self.model.json = dict(self)
             flag_modified(self.model, 'json')

--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -168,11 +168,6 @@ class Record(RecordBase):
         #. The signal :data:`invenio_records.signals.after_record_insert` is
             called with the data as function parameter.
 
-        :param data: Dict with record metadata.
-        :param id_: Force the UUID for the record.
-        :param \**kwargs: See below.
-        :returns: A new Record instance.
-
         :Keyword Arguments:
           * **format_checker** --
             An instance of class :class:`jsonschema.FormatChecker`, which
@@ -183,6 +178,10 @@ class Record(RecordBase):
             A :class:`jsonschema.IValidator` class that will be used to
             validate. See :func:`~invenio_records.api.RecordBase.validate` for
             details.
+
+        :param data: Dict with record metadata.
+        :param id_: Force the UUID for the record.
+        :returns: A new Record instance.
         """
         from .models import RecordMetadata
         with db.session.begin_nested():
@@ -255,9 +254,6 @@ class Record(RecordBase):
         #. The signal :data:`invenio_records.signals.after_record_insert` is
             called with the record as function parameter.
 
-        :param \**kwargs: See below.
-        :returns: The Record instance.
-
         :Keyword Arguments:
           * **format_checker** --
             An instance of class :class:`jsonschema.FormatChecker`, which
@@ -268,6 +264,8 @@ class Record(RecordBase):
             A :class:`jsonschema.IValidator` class that will be used to
             validate. See :func:`~invenio_records.api.RecordBase.validate` for
             details.
+
+        :returns: The Record instance.
         """
         if self.model is None or self.model.json is None:
             raise MissingModelError()

--- a/invenio_records/validators.py
+++ b/invenio_records/validators.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015, 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Validators."""
+
+from __future__ import absolute_import, print_function
+
+from jsonschema.validators import Draft4Validator, extend
+
+
+PartialDraft4Validator = extend(Draft4Validator, {'required': None})
+"""Partial JSON Schema (draft 4) validator.
+
+Special validator that contains the same validation rules of Draft4Validator,
+except for required fields.
+"""


### PR DESCRIPTION
* Adds a new special validator that contains the same validation
  rules of Draft4Validator, except for required fields.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>