### PR TITLE
cli: full deletion of soft-deleted records

### DIFF
--- a/invenio_records/cli.py
+++ b/invenio_records/cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -161,8 +161,7 @@ def patch(patch, ids):
 def delete(ids, force):
     """Delete bibliographic record(s)."""
     from .api import Record
-    from .models import RecordMetadata
     for id_ in ids:
-        record = Record.get_record(id_)
+        record = Record.get_record(id_, with_deleted=force)
         record.delete(force=force)
     db.session.commit()

--- a/tests/test_invenio_records.py
+++ b/tests/test_invenio_records.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -310,6 +310,15 @@ def test_cli(app, db):
         assert result.exit_code == 0
         with app.app_context():
             assert RM.query.get(recid1).json is None
+
+        result = runner.invoke(
+            cli.records,
+            ['delete', '-i', recid1, '--force'],
+            obj=script_info
+        )
+        assert result.exit_code == 0
+        with app.app_context():
+            assert RM.query.get(recid1) is None
 
         result = runner.invoke(
             cli.records,


### PR DESCRIPTION
* FIX Allows to fully delete a record that was already soft-deleted.
  (closes #173)

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>