### PR TITLE
global: bibliographic demo records with wrong marc

### DIFF
--- a/invenio_records/data/marc21/bibliographic.xml
+++ b/invenio_records/data/marc21/bibliographic.xml
@@ -5638,7 +5638,7 @@ Only the mountain and I.
       <subfield code="x">0003-6951</subfield>
       <subfield code="y">2007</subfield>
     </datafield>
-    <datafield tag="856" ind1="7" ind2=" ">
+    <datafield tag="856" ind1="4" ind2=" ">
       <subfield code="u">http://dx.doi.org/10.1063/1.2737136</subfield>
     </datafield>
     <datafield tag="913" ind1=" " ind2=" ">
@@ -5818,7 +5818,7 @@ Only the mountain and I.
       <subfield code="x">0255-5476</subfield>
       <subfield code="y">2010</subfield>
     </datafield>
-    <datafield tag="856" ind1="7" ind2=" ">
+    <datafield tag="856" ind1="4" ind2=" ">
       <subfield code="u">http://dx.doi.org/10.4028/www.scientific.net/MSF.638-642.1098</subfield>
     </datafield>
     <datafield tag="913" ind1=" " ind2=" ">


### PR DESCRIPTION
* Fixes MARC indicator for two example records. (closes #169)

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>