### PR TITLE
tests: fix exit_code for CliRunner exceptions

### DIFF
--- a/tests/test_invenio_records.py
+++ b/tests/test_invenio_records.py
@@ -227,7 +227,7 @@ def test_cli(app, db):
             ['create', 'record.json', '-i', recid1, '--id', recid2],
             obj=script_info
         )
-        assert result.exit_code == -1
+        assert result.exit_code == 1
 
         result = runner.invoke(
             cli.records,
@@ -252,7 +252,7 @@ def test_cli(app, db):
             ['create', 'records.json', '-i', recid1],
             obj=script_info
         )
-        assert result.exit_code == -1
+        assert result.exit_code == 1
 
         result = runner.invoke(
             cli.records,


### PR DESCRIPTION
* Changes the expected exit_code to 1, for compatibility
  with click>=7.0.
  Relevant issue:
  https://github.com/inveniosoftware/troubleshooting/issues/41

Closes #198 

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>