### PR TITLE
installation: relax Flask version to 0.11.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.2.1 (released 2019-05-14)
+
+- Relax Flask dependency to v0.11.1.
+
 Version 1.2.0 (released 2019-05-08)
 
 - Allow to store RecordMetadata in a custom db table.

--- a/invenio_records/version.py
+++ b/invenio_records/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/setup.py
+++ b/setup.py
@@ -65,11 +65,12 @@ setup_requires = [
 install_requires = [
     'blinker>=1.4',
     'flask-celeryext>=0.2.2',
-    'Flask>=1.0',
+    'flask>=0.11.1',
     'jsonpatch>=1.15',
     'jsonresolver>=0.1.0',
     'jsonref>=0.1',
     'jsonschema>=2.5.1',
+    'werkzeug>=0.14.1',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Specifies "werkzeug>0.14.1" in "install_required" in order for
  "requirements-builder" to install the correct version. (closes #209)