### PR TITLE
dumpers: remove @-prefix from model fields

### DIFF
--- a/invenio_records/dumpers/elasticsearch.py
+++ b/invenio_records/dumpers/elasticsearch.py
@@ -46,8 +46,8 @@ class ElasticsearchDumper(Dumper):
         """."""
         self._extensions = extensions or []
         self._model_fields = {
-            'id': ('@uuid', UUID),
-            'version_id': ('@version_id', int),
+            'id': ('uuid', UUID),
+            'version_id': ('version_id', int),
             'created': ('created', datetime),
             'updated': ('updated', datetime),
         }
@@ -190,8 +190,8 @@ class ElasticsearchDumper(Dumper):
         The method adds the following keys (if the record has an associated
         model):
 
-        - ``@uuid`` - UUID of the record.
-        - ``@revision`` -  the revision id of the record.
+        - ``uuid`` - UUID of the record.
+        - ``version_id`` -  the revision id of the record.
         - ``created`` - Creation timestamp in UTC.
         - ``updated`` - Modification timestamp in UTC.
         """

--- a/invenio_records/systemfields/model.py
+++ b/invenio_records/systemfields/model.py
@@ -46,10 +46,9 @@ class ModelField(SystemField):
         """The dictionary key to use in dump output.
 
         Note, it's up to the dumper to choose if it respects this name.
-        The name defaults to the model field name prefixed with @ (e.g.
-        ``expires_at`` becomes ``@expires_at``)
+        The name defaults to the model field name.
         """
-        return self._dump_key or '@{}'.format(self.model_field_name)
+        return self._dump_key or self.model_field_name
 
     @property
     def dump_type(self):

--- a/tests/test_api_dumpers.py
+++ b/tests/test_api_dumpers.py
@@ -47,8 +47,8 @@ def es_hit():
         "_primary_term": 1,
         "found": True,
         "_source": {
-            "@id": "4beb3b3e-a935-442e-a47b-6d386947ea20",
-            "@version_id": 4,
+            "uuid": "4beb3b3e-a935-442e-a47b-6d386947ea20",
+            "version_id": 4,
             "created": "2020-09-01T14:26:00+00:00",
             "updated": "2020-09-02T14:28:21.968149+00:00'",
             "id": "12345-abcde",
@@ -67,7 +67,7 @@ def test_esdumper_without_model(testapp, db, example_data):
     """Test the Elasticsearch dumper."""
     # Dump without a model.
     dump = Record(example_data).dumps(dumper=ElasticsearchDumper())
-    for k in ['@uuid', '@version_id', 'created', 'updated']:
+    for k in ['uuid', 'version_id', 'created', 'updated']:
         assert dump[k] is None  # keys is set to none without a model
     # Load without a model defined
     record = Record.loads(dump, loader=ElasticsearchDumper())
@@ -83,8 +83,8 @@ def test_esdumper_with_model(testapp, db, example_data):
 
     # Dump it
     dump = record.dumps(dumper=ElasticsearchDumper())
-    assert dump['@uuid'] == str(record.id)
-    assert dump['@version_id'] == record.revision_id + 1
+    assert dump['uuid'] == str(record.id)
+    assert dump['version_id'] == record.revision_id + 1
     assert dump['created'][:19] == record.created.isoformat()[:19]
     assert dump['updated'][:19] == record.updated.isoformat()[:19]
 


### PR DESCRIPTION
* The @ prefix was used to separate metadata fields from other fields,
  however it wasn't used consistently, and using it will make it harder
  (though not impossible) to later use e.g. Elasticsearch DSL Document
  class for defining indexes.