### PR TITLE
ext: configurable local ref resolver store

### DIFF
--- a/invenio_records/config.py
+++ b/invenio_records/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2021 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,4 +12,18 @@ RECORDS_VALIDATION_TYPES = {}
 """Pass additional types when validating a record against a schema.
 For more details, see:
 `<https://python-jsonschema.readthedocs.io/en/latest/validate/#validating-types>`_.
+"""
+
+RECORDS_REFRESOLVER_CLS = None
+"""Custom JSONSchemas ref resolver class.
+
+Note that when using a custom ref resolver class you should also set
+``RECORDS_REFRESOLVER_STORE`` to point to a JSONSchema ref resolver store.
+"""
+
+RECORDS_REFRESOLVER_STORE = None
+"""JSONSchemas ref resolver store.
+
+Used together with ``RECORDS_REFRESOLVER_CLS`` to provide a specific
+ref resolver store.
 """

--- a/invenio_records/errors.py
+++ b/invenio_records/errors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2021 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -15,3 +15,7 @@ class RecordsError(Exception):
 
 class MissingModelError(RecordsError):
     """Error raised when a record has no model."""
+
+
+class RecordsRefResolverConfigError(RecordsError):
+    """Custom ref resolver configuration it not correct."""

--- a/invenio_records/ext.py
+++ b/invenio_records/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2021 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,16 @@
 """Invenio module for metadata storage."""
 
 
+from invenio_base.utils import obj_or_import_string
 from jsonref import JsonRef
 from jsonresolver import JSONResolver
 from jsonresolver.contrib.jsonref import json_loader_factory
 from jsonresolver.contrib.jsonschema import ref_resolver_factory
 from jsonschema import validate
+from jsonschema.compat import lru_cache
+
+from invenio_records.errors import RecordsRefResolverConfigError
+from invenio_records.resolver import urljoin_with_custom_scheme
 
 from . import config
 
@@ -25,17 +30,34 @@ class _RecordsState(object):
         """Initialize state."""
         self.app = app
         self.resolver = JSONResolver(entry_point_group=entry_point_group)
-        self.ref_resolver_cls = ref_resolver_factory(self.resolver)
+        self.refresolver_cls = ref_resolver_factory(self.resolver)
+        self.refresolver_store = None
+        if (
+            self.app.config.get("RECORDS_REFRESOLVER_CLS")
+        ):
+            self.refresolver_cls = obj_or_import_string(
+                self.app.config.get("RECORDS_REFRESOLVER_CLS"),
+            )
+            self.refresolver_store = obj_or_import_string(
+                self.app.config.get("RECORDS_REFRESOLVER_STORE")
+            )
+
         self.loader_cls = json_loader_factory(self.resolver)
 
     def validate(self, data, schema, **kwargs):
         """Validate data using schema with ``JSONResolver``."""
         if not isinstance(schema, dict):
             schema = {'$ref': schema}
+        refresolver_cls_kwargs = {}
+        if self.refresolver_store:
+            refresolver_cls_kwargs['store'] = self.refresolver_store
+            refresolver_cls_kwargs['urljoin_cache'] = \
+                lru_cache(1024)(urljoin_with_custom_scheme)
         return validate(
             data,
             schema,
-            resolver=self.ref_resolver_cls.from_schema(schema),
+            resolver=self.refresolver_cls.from_schema(
+                schema, **refresolver_cls_kwargs),
             types=self.app.config.get('RECORDS_VALIDATION_TYPES', {}),
             **kwargs
         )
@@ -75,3 +97,12 @@ class InvenioRecords(object):
         for k in dir(config):
             if k.startswith('RECORDS_'):
                 app.config.setdefault(k, getattr(config, k))
+
+        if (
+            app.config.get("RECORDS_REFRESOLVER_CLS")
+            and not app.config.get("RECORDS_REFRESOLVER_STORE")
+        ):
+            raise RecordsRefResolverConfigError(
+                "RECORDS_REFRESOLVER_CLS config requires "
+                "RECORDS_REFRESOLVER_STORE to be set."
+            )

--- a/invenio_records/resolver.py
+++ b/invenio_records/resolver.py
@@ -1,0 +1,44 @@
+
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2021 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""InvenioRefResolver."""
+
+import urllib.parse
+
+from jsonschema import RefResolutionError, RefResolver
+from jsonschema.compat import urljoin
+
+
+class InvenioRefResolver(RefResolver):
+    """Local Invenio JSONSchemas ref resolver class."""
+
+    def resolve_remote(self, uri):
+        """Block remote ref resolve."""
+        raise RefResolutionError(
+            "{uri} not found in local registry.".format(uri=uri))
+
+
+def urljoin_with_custom_scheme(*args, **kwargs):
+    """Patch urljoin call when using local store with custom schemes.
+
+    Allows using custom schemes by extending urllib.parse
+    configuration (work-around suggested in
+    https://bugs.python.org/issue18828). This patch won't
+    be needed once https://github.com/Julian/jsonschema/issues/649
+    gets fixed.
+    """
+    for arg in args:
+        if isinstance(arg, str) and "://" in arg:
+            scheme = arg.split("://")[0]
+            if scheme not in urllib.parse.uses_relative:
+                urllib.parse.uses_relative.append(scheme)
+            if scheme not in urllib.parse.uses_netloc:
+                urllib.parse.uses_netloc.append(scheme)
+
+    return urljoin(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 
+invenio_db_version = '>=1.0.9,<1.1.0'
+
 tests_require = [
     'pytest-invenio>=1.4.1',
 ]
@@ -25,13 +27,13 @@ extras_require = {
         'Sphinx>=2.4',
     ],
     'mysql': [
-        'invenio-db[mysql,versioning]>=1.0.5',
+        f'invenio-db[mysql,versioning]{invenio_db_version}',
     ],
     'postgresql': [
-        'invenio-db[postgresql,versioning]>=1.0.5',
+        f'invenio-db[postgresql,versioning]{invenio_db_version}',
     ],
     'sqlite': [
-        'invenio-db[versioning]>=1.0.5',
+        f'invenio-db[versioning]{invenio_db_version}',
     ],
     'admin': [
         'invenio-admin>=1.2.1',

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2021 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests Invenio-Records JSONSchema ref resolver."""
+
+import pytest
+
+from invenio_records.api import Record
+from invenio_records.resolver import urljoin_with_custom_scheme
+
+
+def local_ref_resolver_store_factory():
+    """Build local JSONSchema ref resolver store."""
+    return {
+        "local://authors.json": {
+            "$id": "local://authors.json",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "local://books.json": {
+            "$id": "local://books.json",
+            "type": "object",
+            "definitions": {
+                "price": {
+                    "type": "string",
+                },
+            },
+            "properties": {
+                "title": {"type": "string"},
+                "price": {"$ref": "#/definitions/price"},
+                "authors": {"$ref": "local://authors.json"},
+            }
+        }
+    }
+
+
+@pytest.fixture(scope='module')
+def app_config(app_config):
+    app_config['RECORDS_REFRESOLVER_CLS'] = \
+        "invenio_records.resolver.InvenioRefResolver"
+    app_config['RECORDS_REFRESOLVER_STORE'] = \
+        local_ref_resolver_store_factory()
+    return app_config
+
+
+def test_invenio_refresolver_with_local_store(db):
+    """Test InvenioRefResolver with local store and complex JSONSchema."""
+    data = {
+        '$schema': 'local://books.json#',
+        'title': 'The Lord of the Rings',
+        'price': '20',
+        'authors': [
+            'J. R. R. Tolkien',
+        ]
+    }
+    Record.create(data).commit()
+    db.session.commit()
+
+
+@pytest.mark.parametrize(
+    "resolution_scope, scope, expected_output",
+    [
+        # Custom scheme simple cases
+        ("local://books.json", "local://books.json#", "local://books.json"),
+        ("local://books.json#", "local://books.json", "local://books.json"),
+        ("local://books.json#", "#", "local://books.json"),
+        # Custom scheme with internal refs
+        (
+            "local://books.json",
+            "local://books.json#/definitions/price",
+            "local://books.json#/definitions/price"
+        ),
+        (
+            "local://books.json",
+            "#/definitions/price",
+            "local://books.json#/definitions/price"
+        ),
+    ]
+)
+def test_urljoin_with_custom_scheme(resolution_scope, scope, expected_output):
+    """Test urljoin supporting custom schemas."""
+    assert urljoin_with_custom_scheme(
+        resolution_scope, scope) == expected_output


### PR DESCRIPTION
Closes inveniosoftware/invenio-rdm-records#356.

**Progress**:
- [x] New class `InvenioRefResolver` to resolve only local schemas.
- [x] New configuration variable `RECORDS_REFRESOLVER_CLS` to inject custom RefResolver
- [x] New configuration variable `RECORDS_REFRESOLVER_STORE` to inject custom store to the custom RefResolver (`RECORDS_REFRESOLVER_CLS` requires `RECORDS_REFRESOLVER_CLS`)
- [x] Tests
    - [x] Tests with basic Record creation (and validation) using `local://` schemas
    - [x] Test nested schemas
    - [x] Test JSON references

An integration test can be run locally:
- At Invenio-RDM-Records level: https://github.com/inveniosoftware/invenio-rdm-records/pull/492
