### PR TITLE
Make package ready for jsonschema 4.x

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Contributors
 - Rémi Ducceschi
 - Sami Hiltunen
 - Tibor Simko
+- Maximilian Moser

--- a/invenio_records/resolver.py
+++ b/invenio_records/resolver.py
@@ -3,6 +3,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2021 CERN.
+# Copyright (C) 2021 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,7 +13,6 @@
 import urllib.parse
 
 from jsonschema import RefResolutionError, RefResolver
-from jsonschema.compat import urljoin
 
 
 class InvenioRefResolver(RefResolver):
@@ -41,4 +41,4 @@ def urljoin_with_custom_scheme(*args, **kwargs):
             if scheme not in urllib.parse.uses_netloc:
                 urllib.parse.uses_netloc.append(scheme)
 
-    return urljoin(*args, **kwargs)
+    return urllib.parse.urljoin(*args, **kwargs)

--- a/invenio_records/validators.py
+++ b/invenio_records/validators.py
@@ -2,13 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2021      TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Record validators."""
 
-from jsonschema.validators import Draft4Validator, extend
+from jsonschema.validators import Draft4Validator, extend, validator_for
 
 PartialDraft4Validator = extend(Draft4Validator, {'required': None})
 """Partial JSON Schema (draft 4) validator.
@@ -16,3 +17,50 @@ PartialDraft4Validator = extend(Draft4Validator, {'required': None})
 Special validator that contains the same validation rules of Draft4Validator,
 except for required fields.
 """
+
+
+def _generate_legacy_type_checks(types):
+    """Generate new-style type mappings from old-style type mappings.
+
+    Based on the function `jsonschema.validators._generate_legacy_type_checks`
+    from jsonschema 3.x.
+
+    :param types: A mapping of type names to their Python types
+    :returns: A dictionary of definitions that can be passed to `TypeChecker`s
+    """
+
+    def gen_type_check(pytypes):
+        def type_check(_checker, instance):
+            return isinstance(instance, pytypes)
+
+        return type_check
+
+    return {
+        typename: gen_type_check(pytypes)
+        for (typename, pytypes) in types.items()
+    }
+
+
+def _create_validator(schema, base_validator_cls=None, custom_checks=None):
+    """Create a fitting jsonschema validator class.
+
+    :param schema: The schema for which to create a fitting validator
+    :param base_validator_cls: The base :class:`jsonschema.IValidator` class
+        to base the new validator class on -- if not specified, the base
+        class will be determined by the given schema.
+    :param custom_checks: A dictionary with type names and Python types
+        to check against, e.g. {"string": str, "object": dict}
+    :returns: An fitting :class:`jsonschema.IValidator` class
+    """
+    validator_cls = base_validator_cls or validator_for(schema)
+    if custom_checks:
+        type_checker = validator_cls.TYPE_CHECKER.redefine_many(
+            _generate_legacy_type_checks(custom_checks)
+        )
+
+        validator_cls = extend(
+            validator_cls,
+            type_checker=type_checker,
+        )
+
+    return validator_cls

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2021      TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -59,7 +60,7 @@ install_requires = [
     'jsonpatch>=1.26',
     'jsonref>=0.2',
     'jsonresolver>=0.3.1',
-    'jsonschema>=3.0.0,<4.0.0',
+    'jsonschema>=3.0.0,<5.0.0',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Invenio-Records has been relying on functionality for setting custom type checkers that has been deprecated in `jsonschema` 3.x and removed in 4.x.
This PR reimplements the offending code in Invenio-Records (more information in https://github.com/inveniosoftware/invenio-records/issues/269) in such a way that it works with both `jsonschema` 3.x as well as 4.x.

While the problem could be avoided by pinning the `jsonschema` version to `<4` (as has been the case in the 1.5.0 pre-releases before this PR), I feel that updating the behaviour of Invenio-Records may be inevitable at some point anyway.
Possibly the `RECORDS_VALIDATION_TYPES` feature should be generally revisited.