### PR TITLE
dumpers: add indexed time

### DIFF
--- a/invenio_records/dumpers/indexedat.py
+++ b/invenio_records/dumpers/indexedat.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2022 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Indexed timestamp dumper.
+
+Dumper used to dump/load the indexed time of a record to/from an
+ElasticSearch body.
+"""
+
+import arrow
+
+from .elasticsearch import ElasticsearchDumperExt
+
+
+class IndexedAtDumperExt(ElasticsearchDumperExt):
+    """Dumper for the indexed_at field."""
+
+    def __init__(self, key="indexed_at"):
+        """Initialize the dumper."""
+        self.key = key
+
+    def dump(self, record, data):
+        """Dump relations."""
+        data[self.key] = arrow.utcnow().isoformat()
+
+    def load(self, data, record_cls):
+        """Load (remove) indexed data."""
+        data.pop(self.key, None)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 
-invenio_db_version = '>=1.0.9,<1.1.0'
+invenio_db_version = '>=1.0.14,<1.1.0'
 
 tests_require = [
     'pytest-invenio>=1.4.1',
@@ -54,7 +54,7 @@ setup_requires = [
 
 install_requires = [
     'arrow>=0.16.0',
-    'invenio-base>=1.2.7',
+    'invenio-base>=1.2.11',
     'invenio-celery>=1.2.2',
     'invenio-i18n>=1.2.0',
     'jsonpatch>=1.26',


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-records/issues/278

@slint Tests are failing beacuase of `LocalStack` (i.e. Flask 2.1 integration). If the PR changes are approved, I will fix the tests before merging.