### PR TITLE
systemfields: fixed dereferencing for unexisting attrs

### DIFF
--- a/invenio_records/systemfields/relations/results.py
+++ b/invenio_records/systemfields/relations/results.py
@@ -116,8 +116,10 @@ class RelationResult:
         else:
             new_obj = {}
             for k in keys:
-                if dict_lookup(obj, k):
+                try:
                     dict_set(new_obj, k, dict_lookup(obj, k))
+                except KeyError:
+                    pass
             data.update(new_obj)
 
         # From record attributes (i.e. system fields)


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1358

- Fixed an issue where non-existent attributes would raise a `KeyError` when dereferencing. This would prevent the rest of the attributes from being dereferenced. 

`dict_lookup` raises an exception, does not return `None`, if not found. In addition, it does not accept a default value. Therefore, we need to `try/except`.