### PR TITLE
systemfields: fixed dereference for empty keys.

### DIFF
--- a/invenio_records/systemfields/relations/results.py
+++ b/invenio_records/systemfields/relations/results.py
@@ -117,7 +117,9 @@ class RelationResult:
             new_obj = {}
             for k in keys:
                 try:
-                    dict_set(new_obj, k, dict_lookup(obj, k))
+                    val = dict_lookup(obj, k)
+                    if val:
+                        dict_set(new_obj, k, val)
                 except KeyError:
                     pass
             data.update(new_obj)


### PR DESCRIPTION
Fixes an issue added in https://github.com/inveniosoftware/invenio-records/commit/c74c569c552d21c756a3579c715c105131c9dad9

There are two scenarios that should be considered when dereferencing a record:

1. The key does not exist, and `dict_lookup` throws an exception. In that case, the rest of the record can still be dereferenced. 
2. The key exists but has an empty value (e.g. empty string). In that case, it should be discarded. 
