### PR TITLE
dumpers: revert dict merging of dumps

### DIFF
--- a/invenio_records/dumpers/base.py
+++ b/invenio_records/dumpers/base.py
@@ -10,8 +10,6 @@
 
 from copy import deepcopy
 
-from ..dictutils import dict_merge
-
 
 class Dumper:
     """Interface for dumpers."""
@@ -29,10 +27,13 @@ class Dumper:
         :param record: The record to dump.
         :param data: The initial dump data passed in by ``record.dumps()``.
         """
-        copied_record = deepcopy(dict(record))
-        # we merge the cloned record to dumped data so we keep any prior modification that
-        # e.g systemfields have done in the `pre_dump()` step
-        dict_merge(data, copied_record)
+        # We on purpose do not dict merge the record into the data. "data"
+        # holds whatever pre_dump() extensions decided to include, pre_dump
+        # methods should always write to top-level keys that are not
+        # conflicting with any of the record's keys. pre_dump methods can be
+        # used to preprocess the record before dumping (e.g. caching/fetching
+        # things.
+        data.update(deepcopy(dict(record)))
         return data
 
     def load(self, data, record_cls):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Please describe briefly your pull request.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
