### PR TITLE
fix: Error messages for relations

### DIFF
--- a/invenio_records/systemfields/relations/relations.py
+++ b/invenio_records/systemfields/relations/relations.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -113,7 +114,9 @@ class RelationBase:
 
             parent[keys[-1]] = store_value
         else:
-            raise InvalidRelationValue("Invalid field value.")
+            raise InvalidRelationValue(
+                f"Invalid relation value {value!r} for field {self.key!r}."
+            )
 
     def clear_value(self, record):
         """Clear the relation value."""
@@ -160,7 +163,9 @@ class ListRelation(RelationBase):
                 ]
             return [super(ListRelation, self).parse_value(v) for v in value]
         else:
-            raise InvalidRelationValue("Invalid value. Expected list.")
+            raise InvalidRelationValue(
+                f"Invalid relation value {value!r} for field {self.key!r}. Expected list."
+            )
 
     def _get_parent(self, record, keys):
         """Get parent dict."""
@@ -200,7 +205,12 @@ class ListRelation(RelationBase):
 
             parent[store_key] = values_list
         else:
-            raise InvalidRelationValue("Invalid values.")
+            non_existing_values = ",".join(
+                [repr(i) for i in store_values if not self.exists(i)]
+            )
+            raise InvalidRelationValue(
+                f"Invalid relation value(s) {non_existing_values} for field {self.value_key!r}."
+            )
 
     def clear_value(self, record):
         """Clear the relation value."""
@@ -296,7 +306,9 @@ class NestedListRelation(ListRelation):
                     )
             return outter_list
         else:
-            raise InvalidRelationValue("Invalid value. Expected list.")
+            raise InvalidRelationValue(
+                f"Invalid relation value {value!r} for field {self.key!r}. Expected list."
+            )
 
     def set_value(self, record, value):
         """Set the relation value."""

--- a/invenio_records/systemfields/relations/results.py
+++ b/invenio_records/systemfields/relations/results.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020-2024 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,6 +10,9 @@
 """Relations system field."""
 
 from itertools import chain
+
+from arrow import get
+from IPython.testing.decorators import f
 
 from ...dictutils import dict_lookup, dict_set
 from .errors import InvalidCheckValue, InvalidRelationValue
@@ -45,26 +49,46 @@ class RelationResult:
         """Checks if the value is present in the object."""
         for key, value in value_to_check.items():
             if key not in object:
-                raise InvalidCheckValue(f"Invalid key {key}.")
+                # this part is invoked both for list relations and non-list relations
+                relation_field = getattr(self.field, "relation_field", None)
+                if relation_field:
+                    full_key = f"{self.field.key}.{self.field.relation_field}"
+                else:
+                    full_key = self.field.key
+                raise InvalidCheckValue(
+                    f"Invalid relation value: key {key!r} not present in object {object!r} for field {full_key!r}."
+                )
             if isinstance(value, dict):
                 self._value_check(value, object[key])
             else:
                 if not isinstance(value, list):
+                    # this part is invoked both for list relations and non-list relations
+                    relation_field = getattr(self.field, "relation_field", None)
+                    if relation_field:
+                        full_key = f"{self.field.key}.{relation_field}"
+                    else:
+                        full_key = self.field.key
                     raise InvalidCheckValue(
-                        f"Invalid value_check value: {value}; it must be " "a list"
+                        f"Invalid relation value_check value {value!r} for field {full_key!r}, expected list."
                     )
                 elif isinstance(object[key], list):
                     value_exist = set(object[key]).intersection(set(value))
                     if not value_exist:
                         raise InvalidCheckValue(
-                            f"Failed cross checking value_check value "
-                            f"{value} with record value {object[key]}."
+                            f"Failed cross checking value "
+                            f"{value!r} with record value {object[key]!r} for key {self.field.key!r}."
                         )
                 else:
                     if object[key] not in value:
+                        # this part is invoked both for list relations and non-list relations
+                        relation_field = getattr(self.field, "relation_field", None)
+                        if relation_field:
+                            full_key = f"{self.field.key}.{self.field.relation_field}"
+                        else:
+                            full_key = self.field.key
                         raise InvalidCheckValue(
-                            f"Failed cross checking value_check value "
-                            f"{value} with record value {object[key]}."
+                            f"Failed cross checking value "
+                            f"{value!r} with record value {object[key]!r} for key {full_key!r}."
                         )
 
     def validate(self):
@@ -72,7 +96,9 @@ class RelationResult:
         try:
             val = self._lookup_id()
             if not self.exists(val):
-                raise InvalidRelationValue(f"Invalid value {val}.")
+                raise InvalidRelationValue(
+                    f"Invalid relation value {val!r} for field {self.field.value_key!r}."
+                )
             if self.value_check:
                 data = self._lookup_data()
                 obj = self.resolve(data[self.field._value_key_suffix])
@@ -172,12 +198,20 @@ class RelationListResult(RelationResult):
         try:
             values = self._lookup_data()
             if values and not isinstance(values, list):
-                raise InvalidRelationValue(f"Invalid value {values}, should be list.")
+                raise InvalidRelationValue(
+                    f"Invalid relation value {values!r} for field {self.field.key!r}, expected list."
+                )
 
             for v in values:
                 relation_id = self._lookup_id(v)
                 if not self.exists(relation_id):
-                    raise InvalidRelationValue(f"Invalid value {relation_id}.")
+                    if self.field.relation_field:
+                        full_key = f"{self.field.key}.{self.field.relation_field}.{self.field._value_key_suffix}"
+                    else:
+                        full_key = f"{self.field.key}.{self.field._value_key_suffix}"
+                    raise InvalidRelationValue(
+                        f"Invalid relation value {relation_id!r} for field {full_key!r}."
+                    )
                 if self.value_check:
                     obj = self.resolve(v[self.field._value_key_suffix])
                     self._value_check(self.value_check, obj)
@@ -258,17 +292,31 @@ class RelationNestedListResult(RelationListResult):
         try:
             values = self._lookup_data()
             if values and not isinstance(values, list):
-                raise InvalidRelationValue(f"Invalid value {values}, should be list.")
+                raise InvalidRelationValue(
+                    f"Invalid relation value {values!r} for field {self.field.value_key!r}, expected list."
+                )
 
             for outter_v in values:
                 if outter_v and not isinstance(outter_v, list):
+                    if self.field.relation_field:
+                        full_key = f"{self.field.key}.{self.relation_field}"
+                    else:
+                        full_key = self.field.key
                     raise InvalidRelationValue(
-                        f"Invalid inner value {outter_v}, should be list."
+                        f"Invalid relation inner value {outter_v!r} for field {full_key!r}, expected list."
                     )
                 for v in outter_v:
                     relation_id = self._lookup_id(v)
                     if not self.exists(relation_id):
-                        raise InvalidRelationValue(f"Invalid value {relation_id}.")
+                        if self.relation_field:
+                            full_key = f"{self.field.key}.{self.relation_field}.{self.field._value_key_suffix}"
+                        else:
+                            full_key = (
+                                f"{self.field.key}.{self.field._value_key_suffix}"
+                            )
+                        raise InvalidRelationValue(
+                            f"Invalid relation value {relation_id!r} for field {full_key!r}."
+                        )
                     if self.value_check:
                         obj = self.resolve(v[self.field._value_key_suffix])
                         self._value_check(self.value_check, obj)

--- a/tests/test_relations_field.py
+++ b/tests/test_relations_field.py
@@ -2,12 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test Relations fields."""
 
+import re
 from collections.abc import Iterable
 
 import pytest
@@ -115,11 +117,17 @@ def test_multirelations_field(testapp, db, languages):
     _assert_iter_and_lang_from_record(record)
 
     record["languages"] = {"id": "invalid"}
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value {'id': 'invalid'} for field 'languages', expected list.",
+    ):
         record.commit()  # fails validation
     record["languages"] = [{"id": str(en_lang.id)}]
     record["inner"]["inner_languages"] = {"id": "invalid"}
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value {'id': 'invalid'} for field 'inner.inner_languages', expected list.",
+    ):
         record.commit()  # fails validation
 
     # Set via attribute
@@ -155,11 +163,27 @@ def test_multirelations_field(testapp, db, languages):
     record.relations.languages = [str(en_lang.id)]
     record.relations.inner_languages = [str(fr_lang.id)]
 
-    for v in ("invalid", ["invalid"]):
-        with pytest.raises(InvalidRelationValue):
+    for v, error_message, inner_error_message in zip(
+        ("invalid", ["invalid"]),
+        (
+            "Invalid relation value 'invalid' for field 'languages'. Expected list.",
+            "Invalid relation value(s) 'invalid' for field 'languages.id'.",
+        ),
+        (
+            "Invalid relation value 'invalid' for field 'inner.inner_languages'. Expected list.",
+            "Invalid relation value(s) 'invalid' for field 'inner.inner_languages.id'.",
+        ),
+    ):
+        with pytest.raises(
+            InvalidRelationValue,
+            match=re.escape(error_message),
+        ):
             record.relations.languages = v
 
-        with pytest.raises(InvalidRelationValue):
+        with pytest.raises(
+            InvalidRelationValue,
+            match=re.escape(inner_error_message),
+        ):
             record.relations.inner_languages = v
         # Check that old value is still there
         assert record["languages"][0]["id"] == str(en_lang.id)

--- a/tests/test_relations_systemfield.py
+++ b/tests/test_relations_systemfield.py
@@ -2,12 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020-2024 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Tests for relations system field."""
 
+import re
 from collections.abc import Iterable
 
 import pytest
@@ -71,7 +73,10 @@ def test_relations_field_pk_relation(testapp, db, languages):
     assert res == en_lang
 
     record["language"] = {"id": "invalid"}
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value 'invalid' for field 'language.id'",
+    ):
         record.commit()  # fails validation
 
     # Set via attribute
@@ -90,7 +95,10 @@ def test_relations_field_pk_relation(testapp, db, languages):
     assert res == fr_lang
 
     # Set invalid value
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value 'invalid' for field 'language'",
+    ):
         record.relations.language = "invalid"
     # Check that old value is still there
     assert record["language"]["id"] == str(fr_lang.id)
@@ -181,7 +189,10 @@ def test_relations_field_pk_list_relation(testapp, db, languages):
     res = next(res_iter)
     assert res == en_lang
     record["languages"] = {"id": "invalid"}
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match=f"Invalid relation value {record['languages']!r} for field 'languages', expected list.",
+    ):
         record.commit()  # fails validation
 
     # Set via attribute
@@ -202,8 +213,14 @@ def test_relations_field_pk_list_relation(testapp, db, languages):
     assert res == fr_lang
 
     # Set invalid value
-    for v in ("invalid", ["invalid"]):
-        with pytest.raises(InvalidRelationValue):
+    for v, expected_error in zip(
+        ("invalid", ["invalid"]),
+        (
+            "Invalid relation value 'invalid' for field 'languages'. Expected list.",
+            "Invalid relation value(s) 'invalid' for field 'languages.id'.",
+        ),
+    ):
+        with pytest.raises(InvalidRelationValue, match=re.escape(expected_error)):
             record.relations.languages = v
         # Check that old value is still there
         assert record["languages"][0]["id"] == str(fr_lang.id)
@@ -363,7 +380,10 @@ def test_relations_field_pk_list_relation_of_objects(testapp, db, languages):
         },
         {"field1": "testString"},
     ]
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value 'invalid' for field 'array_of_objects.language.id'.",
+    ):
         record.commit()  # fails validation
 
     # Set via attribute
@@ -411,7 +431,10 @@ def test_relations_field_pk_list_relation_of_objects(testapp, db, languages):
     assert res == es_lang
 
     # Set invalid value
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value 'invalid' for field 'array_of_objects'. Expected list.",
+    ):
         record.relations.array_of_objects = "invalid"
     # Check that old value is still there
     assert record["array_of_objects"][0]["language"]["id"] == str(en_lang.id)
@@ -676,7 +699,10 @@ def test_relations_field_pk_nested_list_of_objects_w_related_field(
         },
         {"field1": "testString"},
     ]
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match=f"Invalid relation inner value {record['nested_array_of_objects'][0]['languages']!r} for field 'nested_array_of_objects.languages', expected list.",
+    ):
         record.commit()  # fails validation
 
     # fails with invalid values
@@ -689,7 +715,10 @@ def test_relations_field_pk_nested_list_of_objects_w_related_field(
         },
         {"field1": "testString"},
     ]
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value 'invalid' for field 'nested_array_of_objects.languages.id'.",
+    ):
         record.commit()  # fails validation
 
     # Set via attribute
@@ -729,7 +758,10 @@ def test_relations_field_pk_nested_list_of_objects_w_related_field(
         res = next(res_inner_iter)
 
     # Set invalid value
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value 'invalid' for field 'nested_array_of_objects'. Expected list.",
+    ):
         record.relations.nested_array_of_objects = "invalid"
     # Check that old value is still there
     assert record["nested_array_of_objects"][0]["languages"][0]["id"] == (
@@ -912,12 +944,18 @@ def test_relations_field_pk_nested_list_of_objects_wo_related_field(
 
     # fails with non-list types
     record["nested_languages"] = [{"id": str(es_lang.id)}]
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match=f"Invalid relation inner value {record['nested_languages'][0]!r} for field 'nested_languages', expected list.",
+    ):
         record.commit()  # fails validation
 
     # fails with invalid values
     record["nested_languages"] = [[{"id": "invalid"}]]
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value 'invalid' for field 'nested_languages.id'.",
+    ):
         record.commit()  # fails validation
 
     # Set via attribute
@@ -948,7 +986,10 @@ def test_relations_field_pk_nested_list_of_objects_wo_related_field(
         res = next(res_inner_iter)
 
     # Set invalid value
-    with pytest.raises(InvalidRelationValue):
+    with pytest.raises(
+        InvalidRelationValue,
+        match="Invalid relation value 'invalid' for field 'nested_languages'. Expected list.",
+    ):
         record.relations.nested_languages = "invalid"
     # Check that old value is still there
     assert record["nested_languages"][0][0]["id"] == (str(fr_lang.id))
@@ -1068,13 +1109,21 @@ def test_relations_field_pk_relation_with_value_check(testapp, db, languages):
     record = Record1.create({})
     record["language"] = {"id": str(en_lang.id)}
     # Fails because value_check must be a list
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match="Invalid relation value_check value 'English' for field 'language', expected list.",
+    ):
         record.commit()  # validates
 
     record = Record2.create({})
     record["language"] = {"id": str(es_lang.id)}
     # Fails because only ethnicity accepted is English and French
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match=re.escape(
+            "Failed cross checking value ['English', 'French'] with record value 'Spanish' for key 'language'."
+        ),
+    ):
         record.commit()  # validates
 
     record["language"] = {"id": str(fr_lang.id)}
@@ -1086,14 +1135,24 @@ def test_relations_field_pk_relation_with_value_check(testapp, db, languages):
     record = Record3.create({})
     record["language"] = {"id": str(en_lang.id)}
     # Fails because wrong_value is not a field of the language vocabulary
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match="Invalid relation value: key 'wrong_value' not present in object "
+        "{'iso': 'en', 'title': 'English', 'information': {'ethnicity': 'English', "
+        "'native_speakers': '400 million'}} for field 'language'.",
+    ):
         record.commit()  # validates
 
     record = Record4.create({})
     record["language"] = {"id": str(en_lang.id)}
     # Fails because only records with English ethnicity and 'oe' as iso are
     # accepted
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match=re.escape(
+            "Failed cross checking value ['oe'] with record value 'en' for key 'language'."
+        ),
+    ):
         record.commit()  # validates
 
     record["language"] = {"id": str(oe_lang.id)}
@@ -1160,13 +1219,21 @@ def test_relations_field_pk_list_relation_with_value_check(testapp, db, language
     record = Record1.create({})
     record["languages"] = [{"id": str(fr_lang.id)}]
     # Fails because value_check must be a list
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match="Invalid relation value_check value 'English' for field 'languages', expected list.",
+    ):
         record.commit()  # validates
 
     record = Record2.create({})
     record["languages"] = [{"id": str(es_lang.id)}, {"id": str(en_lang.id)}]
     # Fails because only ethnicity accepted is English and French
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match=re.escape(
+            "Failed cross checking value ['English', 'French'] with record value 'Spanish' for key 'languages'."
+        ),
+    ):
         record.commit()  # validates
 
     record["languages"] = [{"id": str(fr_lang.id)}, {"id": str(en_lang.id)}]
@@ -1179,14 +1246,24 @@ def test_relations_field_pk_list_relation_with_value_check(testapp, db, language
     record = Record3.create({})
     record["languages"] = [{"id": str(en_lang.id)}]
     # Fails because wrong_value is not a field of the language vocabulary
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match="Invalid relation value: key 'wrong_value' not present in object "
+        "{'iso': 'en', 'title': 'English', 'information': {'ethnicity': 'English', "
+        "'native_speakers': '400 million'}} for field 'languages'.",
+    ):
         record.commit()  # validates
 
     record = Record4.create({})
     record["languages"] = [{"id": str(en_lang.id)}]
     # Fails because only records with English ethnicity and 'oe' as iso are
     # accepted
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match=re.escape(
+            "Failed cross checking value ['oe'] with record value 'en' for key 'languages'."
+        ),
+    ):
         record.commit()  # validates
 
     record["languages"] = [{"id": str(oe_lang.id)}]
@@ -1270,7 +1347,10 @@ def test_relations_field_pk_nested_list_of_obj_w_related_field_w_value_check(
         },
     ]
     # Fails because value_check must be a list
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match="Invalid relation value_check value 'English' for field 'nested_array_of_objects.languages', expected list.",
+    ):
         record.commit()  # validates
 
     record = Record2.create({})
@@ -1285,7 +1365,12 @@ def test_relations_field_pk_nested_list_of_obj_w_related_field_w_value_check(
         },
     ]
     # Fails because only ethnicity accepted is English and French
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match=re.escape(
+            "Failed cross checking value ['English', 'French'] with record value 'Spanish' for key 'nested_array_of_objects.languages'."
+        ),
+    ):
         record.commit()  # validates
 
     record["nested_array_of_objects"] = [
@@ -1333,7 +1418,10 @@ def test_relations_field_pk_nested_list_of_obj_w_related_field_w_value_check(
         },
     ]
     # Fails because wrong_value is not a field of the language vocabulary
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match="Invalid relation value: key 'wrong_value' not present in object {'iso': 'en', 'title': 'English', 'information': {'ethnicity': 'English', 'native_speakers': '400 million'}} for field 'nested_array_of_objects.languages'.",
+    ):
         record.commit()  # validates
 
     record = Record4.create({})
@@ -1341,7 +1429,12 @@ def test_relations_field_pk_nested_list_of_obj_w_related_field_w_value_check(
         {"languages": [{"id": str(en_lang.id)}], "field1": "string"}
     ]
     # Fails because only ethnicity accepted is English
-    with pytest.raises(InvalidCheckValue):
+    with pytest.raises(
+        InvalidCheckValue,
+        match=re.escape(
+            "Failed cross checking value ['oe'] with record value 'en' for key 'nested_array_of_objects.languages'."
+        ),
+    ):
         record.commit()  # validates
 
     record["nested_array_of_objects"] = [


### PR DESCRIPTION
### Description

There are two issues with how errors in relation fields (e.g., references to vocabularies) are handled in RDM records.

* Error messages do not clearly indicate where the error occurred and what the error was.
* These errors behave significantly differently from other validation errors. Normally, validation is performed at the service level using the `marshmallow` library. This allows even invalid drafts to be saved: incorrect fields are omitted from the draft and validation messages are returned in the `errors` field of the response.

Relation errors, however, are handled later during record commit. As a result, they raise an exception, the draft is not saved, and the response is serialized differently.

This PR addresses only the first issue. The second is architectural in nature, and resolving it would require a larger change that cannot realistically be completed in time for v14.

#### Problem and solution

Previously, relation validation errors used generic messages such as `"Invalid field value"`, which made debugging difficult, especially in complex record structures with nested relations.

This change replaces those generic messages with more specific ones that include:
* the invalid value
* the field path where the error occurred

This makes it significantly easier to identify and resolve relation validation issues during development and debugging.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
