### PR TITLE
fix(tests): enabled alembic tests

### DIFF
--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -12,7 +13,6 @@ import pytest
 from invenio_db.utils import drop_alembic_version_table
 
 
-@pytest.mark.skip(reason="Caused by mergepoint")
 def test_alembic(testapp, db):
     """Test alembic recipes."""
     ext = testapp.extensions["invenio-db"]
@@ -20,15 +20,31 @@ def test_alembic(testapp, db):
     if db.engine.name == "sqlite":
         raise pytest.skip("Upgrades are not supported on SQLite.")
 
-    assert not ext.alembic.compare_metadata()
+    def assert_no_unexpected_migrations():
+        # names created by by other tests and registered to sqlalchemy
+        extra_names = [
+            "custom_metadata",
+            "record1_metadata",
+            "record2_metadata",
+            "record3_metadata",
+            "type_model",
+        ]
+        unexpected_migrations = [
+            m
+            for m in ext.alembic.compare_metadata()
+            if "mock" not in m[1].name.lower() and m[1].name.lower() not in extra_names
+        ]
+        assert unexpected_migrations == []
+
+    assert_no_unexpected_migrations()
     db.drop_all()
     drop_alembic_version_table()
     ext.alembic.upgrade()
 
-    assert not ext.alembic.compare_metadata()
+    assert_no_unexpected_migrations()
     ext.alembic.stamp()
     ext.alembic.downgrade(target="96e796392533")
     ext.alembic.upgrade()
 
-    assert not ext.alembic.compare_metadata()
+    assert_no_unexpected_migrations()
     drop_alembic_version_table()


### PR DESCRIPTION
### Description

Alembic tests were disabled for this package, re-enabling them.

This PR needs https://github.com/inveniosoftware/invenio-accounts/pull/551 to pass

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
