### PR TITLE
chore(deprecation)!: remove deprecated code paths requiring inspect

### DIFF
--- a/invenio_records/api.py
+++ b/invenio_records/api.py
@@ -6,7 +6,6 @@
 
 """Record API."""
 
-import inspect
 import warnings
 from copy import deepcopy
 
@@ -227,29 +226,11 @@ class RecordBase(dict):
 
         # Run pre dump extensions
         for e in self._extensions:
-            pre_dump_params = inspect.signature(e.pre_dump).parameters
-            if "data" in pre_dump_params:
-                e.pre_dump(self, data, dumper=dumper)
-            else:
-                # TODO: Remove in v1.6.0 or later
-                warnings.warn(
-                    "The pre_dump hook must take a positional argument data.",
-                    DeprecationWarning,
-                )
-                e.pre_dump(self, dumper=dumper)
+            e.pre_dump(self, data, dumper=dumper)
 
-        dump_params = inspect.signature(dumper.dump).parameters
-        if "data" in dump_params:
-            # Execute the dump - for backwards compatibility we use the default
-            # dumper which returns a deepcopy.
-            data = dumper.dump(self, data)
-        else:
-            # TODO: Remove in v1.6.0 or later
-            warnings.warn(
-                "The dumper.dump() must take a positional argument data.",
-                DeprecationWarning,
-            )
-            data = dumper.dump(self)
+        # Execute the dump - for backwards compatibility we use the default
+        # dumper which returns a deepcopy.
+        data = dumper.dump(self, data)
 
         for e in self._extensions:
             e.post_dump(self, data, dumper=dumper)
@@ -277,16 +258,7 @@ class RecordBase(dict):
 
         # Run post load extensions
         for e in cls._extensions:
-            post_load_params = inspect.signature(e.post_load).parameters
-            if "data" in post_load_params:
-                e.post_load(record, data, loader=loader)
-            else:
-                # TODO: Remove in v1.6.0 or later
-                warnings.warn(
-                    "The post_load hook must take a positional argument data.",
-                    DeprecationWarning,
-                )
-                e.post_load(record, loader=loader)
+            e.post_load(record, data, loader=loader)
 
         return record
 

--- a/invenio_records/systemfields/base.py
+++ b/invenio_records/systemfields/base.py
@@ -261,58 +261,22 @@ class SystemFieldsExt(RecordExtension):
     def pre_dump(self, record, data, dumper=None):
         """Called before a record is dumped."""
         for field in self.declared_fields.values():
-            pre_dump_params = inspect.signature(field.pre_dump).parameters
-            if "data" in pre_dump_params:
-                field.pre_dump(record, data, dumper=dumper)
-            else:
-                # TODO: Remove in v1.6.0 or later
-                warnings.warn(
-                    "The pre_dump hook must take a positional argument data.",
-                    DeprecationWarning,
-                )
-                field.pre_dump(record, dumper=dumper)
+            field.pre_dump(record, data, dumper=dumper)
 
     def post_dump(self, record, data, dumper=None):
         """Called after a record is dumped."""
         for field in self.declared_fields.values():
-            post_dump_params = inspect.signature(field.post_dump).parameters
-            if "data" in post_dump_params:
-                field.post_dump(record, data, dumper=dumper)
-            else:
-                # TODO: Remove in v1.6.0 or later
-                warnings.warn(
-                    "The post_dump hook must take a positional argument data.",
-                    DeprecationWarning,
-                )
-                field.post_dump(record, dumper=dumper)
+            field.post_dump(record, data, dumper=dumper)
 
     def pre_load(self, data, loader=None):
         """Called before a record is loaded."""
         for field in self.declared_fields.values():
-            pre_load_params = inspect.signature(field.pre_load).parameters
-            if "data" in pre_load_params:
-                field.pre_load(data, loader=loader)
-            else:
-                # TODO: Remove in v1.6.0 or later
-                warnings.warn(
-                    "The pre_load hook must take a positional argument data.",
-                    DeprecationWarning,
-                )
-                field.pre_load(loader=loader)
+            field.pre_load(data, loader=loader)
 
     def post_load(self, record, data, loader=None):
         """Called after a record is loaded."""
         for field in self.declared_fields.values():
-            post_load_params = inspect.signature(field.post_load).parameters
-            if "data" in post_load_params:
-                field.post_load(record, data, loader=loader)
-            else:
-                # TODO: Remove in v1.6.0 or later
-                warnings.warn(
-                    "The post_load hook must take a positional argument data.",
-                    DeprecationWarning,
-                )
-                field.post_load(record, loader=loader)
+            field.post_load(record, data, loader=loader)
 
     def pre_create(self, *args, **kwargs):
         """Called after a record is created."""


### PR DESCRIPTION
I've encountered the `inspect` call in the `post_dump()` code path at least once.
The code path necessitating this check has been deprecated for several years now.
So while this is not a huge performance hog, it's still an easy win if we axe it.

TODO:
- [x] Test manually
- [x] Run testrig (ping @mesemus )